### PR TITLE
Use .zip file in spark documentation

### DIFF
--- a/docs/source/spark.rst
+++ b/docs/source/spark.rst
@@ -30,13 +30,13 @@ Activate the environment:
     $ conda activate example   # Older conda versions use `source activate` instead
 
 
-Package the environment into a ``zip`` archive:
+Package the environment into a ``tar.gz`` archive:
 
 .. code-block:: bash
 
-    $ conda pack -o environment.zip
+    $ conda pack -o environment.tar.gz
     Collecting packages...
-    Packing environment at '/Users/jcrist/anaconda/envs/example' to 'environment.zip'
+    Packing environment at '/Users/jcrist/anaconda/envs/example' to 'environment.tar.gz'
     [########################################] | 100% Completed | 23.2s
 
 
@@ -77,7 +77,7 @@ Submit the job to Spark using ``spark-submit``. In YARN cluster mode:
     --conf spark.yarn.appMasterEnv.PYSPARK_PYTHON=./environment/bin/python \
     --master yarn \
     --deploy-mode cluster \
-    --archives environment.zip#environment \
+    --archives environment.tar.gz#environment \
     script.py
 
 
@@ -91,5 +91,5 @@ Or in YARN client mode:
     --conf spark.yarn.appMasterEnv.PYSPARK_PYTHON=./environment/bin/python \
     --master yarn \
     --deploy-mode client \
-    --archives environment.zip#environment \
+    --archives environment.tar.gz#environment \
     script.py

--- a/docs/source/spark.rst
+++ b/docs/source/spark.rst
@@ -30,13 +30,13 @@ Activate the environment:
     $ conda activate example   # Older conda versions use `source activate` instead
 
 
-Package the environment into a ``tar.gz`` archive:
+Package the environment into a ``zip`` archive:
 
 .. code-block:: bash
 
-    $ conda pack -o environment.tar.gz
+    $ conda pack -o environment.zip
     Collecting packages...
-    Packing environment at '/Users/jcrist/anaconda/envs/example' to 'environment.tar.gz'
+    Packing environment at '/Users/jcrist/anaconda/envs/example' to 'environment.zip'
     [########################################] | 100% Completed | 23.2s
 
 


### PR DESCRIPTION
Previously in the conda-pack part of the example we used tar.gz files
but in the Spark part of the example we used .zip files.

Now we conform to using .zip in both locations

I'm not certain that this is the right move, but it was a quick enough fix to make as a suggestion.