### PR TITLE
Handle KeyboardInterrupt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - pip install .
 
 script:
-  - py.test conda_pack
+  - py.test conda_pack -s -vv
   - flake8 conda_pack
   - |
     if [[ "$DOCS" == "true" ]]; then

--- a/conda_pack/cli.py
+++ b/conda_pack/cli.py
@@ -111,6 +111,9 @@ def main(args=None, pack=pack):
     except CondaPackException as e:
         print("CondaPackError: %s" % e, file=sys.stderr)
         sys.exit(1)
+    except KeyboardInterrupt as e:
+        print("Interrupted", file=sys.stderr)
+        sys.exit(1)
     except Exception as e:
         print(traceback.format_exc(), file=sys.stderr)
         sys.exit(1)

--- a/conda_pack/tests/test_cli.py
+++ b/conda_pack/tests/test_cli.py
@@ -137,8 +137,13 @@ def test_keyboard_interrupt(tmpdir):
     time.sleep(0.5)
     proc.send_signal(signal.SIGINT)
 
-    assert proc.wait() == 1
+    outcode = proc.wait()
 
-    err = proc.stderr.read()
-    assert err.decode() == 'Interrupted\n'
+    out = proc.stdout.read().decode()
+    err = proc.stderr.read().decode()
+
+    print(out)
+    print(err)
+    assert outcode == 1
+    assert err == 'Interrupted\n'
     assert not os.path.exists(out_path)


### PR DESCRIPTION
Catch to avoid outputting trackeback to user.