### PR TITLE
Check for CONDA_EXE env var and then fallback to PATH

### DIFF
--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -496,8 +496,9 @@ def check_no_editable_packages(prefix, site_packages):
 
 def name_to_prefix(name=None):
     try:
-        info = (subprocess.check_output("conda info --json", shell=True,
-                                        stderr=subprocess.PIPE)
+        conda_exe = os.environ.get('CONDA_EXE', 'conda')
+        info = (subprocess.check_output("{} info --json".format(conda_exe),
+                                        shell=True, stderr=subprocess.PIPE)
                           .decode(default_encoding))
     except subprocess.CalledProcessError as exc:
         kind = ('current environment' if name is None


### PR DESCRIPTION
Conda could just be a shell function and not a binary in `PATH`.
```
$ type -a conda
conda is a function
conda () 
{ 
    if [ "$#" -lt 1 ]; then
        $_CONDA_EXE;
    else
        \local cmd="$1";
        shift;
        case "$cmd" in 
            activate)
                _conda_activate "$@"
            ;;
            deactivate)
                _conda_deactivate "$@"
            ;;
            install | update | uninstall | remove)
                $_CONDA_EXE "$cmd" "$@" && _conda_reactivate
            ;;
            *)
                $_CONDA_EXE "$cmd" "$@"
            ;;
        esac;
    fi
}

$ echo $CONDA_EXE
/home/nwani/m3/bin/conda

$ echo $PATH
/tmp/wani.1531021259/test/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/nwani/.local/bin:/home/nwani/bin
```