### PR TITLE
Error nicely if pip clobbers a conda-installed file

### DIFF
--- a/conda_pack/tests/conftest.py
+++ b/conda_pack/tests/conftest.py
@@ -15,6 +15,7 @@ env_dir = os.path.abspath(rel_env_dir)
 py27_path = os.path.join(env_dir, 'py27')
 py36_path = os.path.join(env_dir, 'py36')
 py36_editable_path = os.path.join(env_dir, 'py36_editable')
+py36_broken_path = os.path.join(env_dir, 'py36_broken')
 
 
 def pytest_addoption(parser):

--- a/conda_pack/tests/test_core.py
+++ b/conda_pack/tests/test_core.py
@@ -10,8 +10,8 @@ import pytest
 from conda_pack import CondaEnv, CondaPackException, pack
 from conda_pack.core import name_to_prefix, File
 
-from .conftest import (py36_path, py36_editable_path, py27_path, rel_env_dir,
-                       env_dir)
+from .conftest import (py36_path, py36_editable_path, py36_broken_path,
+                       py27_path, rel_env_dir, env_dir)
 
 
 @pytest.fixture(scope="module")
@@ -77,6 +77,16 @@ def test_errors_editable_packages():
         CondaEnv.from_prefix(py36_editable_path)
 
     assert "Editable packages found" in str(exc.value)
+
+
+def test_errors_pip_overwrites():
+    with pytest.raises(CondaPackException) as exc:
+        CondaEnv.from_prefix(py36_broken_path)
+
+    msg = str(exc.value)
+    assert "pip" in msg
+    assert "toolz" in msg
+    assert "cytoolz" in msg
 
 
 def test_errors_root_environment():

--- a/testing/env_yamls/py36_broken.yml
+++ b/testing/env_yamls/py36_broken.yml
@@ -1,0 +1,11 @@
+name: py36_broken
+
+channels:
+    - conda-forge
+
+dependencies:
+    - cytoolz
+    - toolz
+    - pip:
+        - toolz==0.7.0
+        - cytoolz==0.7.0

--- a/testing/setup_envs.sh
+++ b/testing/setup_envs.sh
@@ -15,3 +15,7 @@ conda env create --force -f "${current_dir}/env_yamls/py36.yml" -p $py36_editabl
 source activate $py36_editable
 pushd "${current_dir}/.." && python setup.py develop && popd
 source deactivate
+
+echo "Creating py36_broken environment"
+py36_broken="${current_dir}/environments/py36_broken"
+conda env create --force -f "${current_dir}/env_yamls/py36_broken.yml" -p $py36_broken


### PR DESCRIPTION
If pip and conda are mixed, sometimes pip will uninstall packages that
are managed by conda. This *can* lead to an inconsistent environment,
and is generally frowned upon. Instead of trying to handle these cases,
we collect packages that have been broken by pip and report a nice error
message on failure.

Fixes #34.