### PR TITLE
Allow conda in environments

### DIFF
--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -737,9 +737,7 @@ def load_environment(prefix, on_missing_cache='warn'):
     # Add unmanaged files
     unmanaged = all_files - managed
     # Remove conda related files if they aren't already claimed by conda
-    # Remove conda-meta history, as it shouldn't be distributed
-    unmanaged -= {'bin/activate', 'bin/deactivate', 'bin/conda',
-                  'conda-meta/history'}
+    unmanaged -= {'bin/activate', 'bin/deactivate', 'bin/conda'}
 
     files.extend(File(os.path.join(prefix, p),
                       p,

--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -724,11 +724,21 @@ def load_environment(prefix, on_missing_cache='warn'):
 
             managed.update(targets)
             files.extend(new_files)
+            # Add conda-meta entry
+            managed.add(os.path.join('conda-meta', path))
             files.append(File(os.path.join(conda_meta, path),
                               os.path.join('conda-meta', path),
                               is_conda=True,
                               prefix_placeholder=None,
                               file_mode=None))
+
+    # Add remaining conda metadata files
+    managed.add(os.path.join('conda-meta', 'history'))
+    files.append(File(os.path.join(conda_meta, 'history'),
+                      os.path.join('conda-meta', 'history'),
+                      is_conda=True,
+                      prefix_placeholder=None,
+                      file_mode=None))
 
     if missing_files:
         packages = '\n'.join('- %s=%r' % i for i in missing_files)
@@ -863,7 +873,7 @@ class Packer(object):
 
     def add(self, file):
         if file.file_mode is None:
-            if file.target.startswith('conda-meta'):
+            if fnmatch(file.target, 'conda-meta/*.json'):
                 self.archive.add_bytes(file.source,
                                        rewrite_conda_meta(file.source),
                                        file.target)

--- a/conda_pack/scripts/posix/activate
+++ b/conda_pack/scripts/posix/activate
@@ -54,7 +54,7 @@ _conda_pack_activate() {
 
     # Run the activate scripts
     local _path
-    for _path in ${full_path_env}/etc/conda/activate.d/*; do
+    for _path in "${full_path_env}/etc/conda/activate.d/*"; do
         if [ -f "$_path" ]; then
             . "$_path"
         fi

--- a/conda_pack/scripts/posix/activate
+++ b/conda_pack/scripts/posix/activate
@@ -33,15 +33,15 @@ _conda_pack_activate() {
     local env_name="$(basename "$full_path_env")"
 
     # If there's already a source env
-    if [ -n "$CONDA_PACK_PREFIX" ]; then
+    if [ -n "$CONDA_PREFIX" ]; then
         # If the source env differs from this env
-        if [ "$CONDA_PACK_PREFIX" != "$full_path_env" ]; then
+        if [ "$CONDA_PREFIX" != "$full_path_env" ]; then
             . "${full_path_script_dir}/deactivate"
         else
             return 0  # nothing to do
         fi
     fi
-    export CONDA_PACK_PREFIX="$full_path_env"
+    export CONDA_PREFIX="$full_path_env"
     export _CONDA_PACK_OLD_PS1="$PS1"
     PATH="$full_path_env/bin:$PATH"
     PS1="($env_name) $PS1"
@@ -54,8 +54,6 @@ _conda_pack_activate() {
 
     # Run the activate scripts
     local _path
-    # Temporarily set CONDA_PREFIX for activate scripts
-    local CONDA_PREFIX=$CONDA_PACK_PREFIX
     for _path in ${full_path_env}/etc/conda/activate.d/*; do
         if [ -f "$_path" ]; then
             . "$_path"

--- a/conda_pack/scripts/posix/deactivate
+++ b/conda_pack/scripts/posix/deactivate
@@ -1,11 +1,9 @@
 _conda_pack_deactivate () {
     # If there's an active environment
-    if [ -n "$CONDA_PACK_PREFIX" ]; then
+    if [ -n "$CONDA_PREFIX" ]; then
         # First run the deactivate scripts
         local _path
-        # Temporarily set CONDA_PREFIX for deactivate scripts
-        local CONDA_PREFIX=$CONDA_PACK_PREFIX
-        for _path in $CONDA_PACK_PREFIX/etc/conda/deactivate.d/*; do
+        for _path in $CONDA_PREFIX/etc/conda/deactivate.d/*; do
             if [ -f "$_path" ]; then
                 . "$_path"
             fi
@@ -13,7 +11,7 @@ _conda_pack_deactivate () {
 
         # Remove env/bin from path
         local IFS=':'
-        local _target="$CONDA_PACK_PREFIX/bin"
+        local _target="$CONDA_PREFIX/bin"
         local _newpath
         local _path
 
@@ -24,7 +22,7 @@ _conda_pack_deactivate () {
         done
 
         PATH="$_newpath"
-        unset CONDA_PACK_PREFIX
+        unset CONDA_PREFIX
         PS1="$_CONDA_PACK_OLD_PS1"
         unset _CONDA_PACK_OLD_PS1
     fi

--- a/conda_pack/scripts/posix/deactivate
+++ b/conda_pack/scripts/posix/deactivate
@@ -3,7 +3,7 @@ _conda_pack_deactivate () {
     if [ -n "$CONDA_PREFIX" ]; then
         # First run the deactivate scripts
         local _path
-        for _path in $CONDA_PREFIX/etc/conda/deactivate.d/*; do
+        for _path in "$CONDA_PREFIX/etc/conda/deactivate.d/*"; do
             if [ -f "$_path" ]; then
                 . "$_path"
             fi

--- a/conda_pack/tests/conftest.py
+++ b/conda_pack/tests/conftest.py
@@ -17,6 +17,7 @@ py36_path = os.path.join(env_dir, 'py36')
 py36_editable_path = os.path.join(env_dir, 'py36_editable')
 py36_broken_path = os.path.join(env_dir, 'py36_broken')
 nopython_path = os.path.join(env_dir, 'nopython')
+has_conda_path = os.path.join(env_dir, 'has_conda')
 
 
 def pytest_addoption(parser):

--- a/conda_pack/tests/test_core.py
+++ b/conda_pack/tests/test_core.py
@@ -271,16 +271,6 @@ def test_pack_with_conda(tmpdir):
         # Extract tarfile
         fil.extractall(extract_path)
 
-    # Check bash scripts all don't error
-    command = (". {path}/bin/activate && "
-               "conda-unpack && "
-               ". {path}/bin/deactivate && "
-               "echo 'Done'").format(path=extract_path)
-
-    out = subprocess.check_output(['/usr/bin/env', 'bash', '-c', command],
-                                  stderr=subprocess.STDOUT).decode()
-    assert out == 'Done\n'
-
     # Check the packaged conda works, and the output is a conda environment
     command = (". {path}/bin/activate && "
                "conda list --json -p {path} &&"

--- a/conda_pack/tests/test_core.py
+++ b/conda_pack/tests/test_core.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, print_function, division
 
-import json
 import os
 import subprocess
 import tarfile
@@ -87,16 +86,6 @@ def test_errors_pip_overwrites():
     assert "pip" in msg
     assert "toolz" in msg
     assert "cytoolz" in msg
-
-
-def test_errors_root_environment():
-    info = subprocess.check_output("conda info --json", shell=True).decode()
-    root_prefix = json.loads(info)['root_prefix']
-
-    with pytest.raises(CondaPackException) as exc:
-        CondaEnv.from_prefix(root_prefix)
-
-    assert "Cannot package root environment" in str(exc.value)
 
 
 def test_errors_conda_missing(bad_conda_exe):

--- a/testing/env_yamls/has_conda.yml
+++ b/testing/env_yamls/has_conda.yml
@@ -1,0 +1,5 @@
+name: has_conda
+
+dependencies:
+    - conda
+    - toolz

--- a/testing/setup_envs.sh
+++ b/testing/setup_envs.sh
@@ -4,20 +4,23 @@ echo "== Setting up environments for testing =="
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 echo "Creating py27 environment"
-conda env create --force -f "${current_dir}/env_yamls/py27.yml" -p "${current_dir}/environments/py27"
+conda env create -f "${current_dir}/env_yamls/py27.yml" -p "${current_dir}/environments/py27" $@
 
 echo "Creating py36 environment"
-conda env create --force -f "${current_dir}/env_yamls/py36.yml" -p "${current_dir}/environments/py36"
+conda env create -f "${current_dir}/env_yamls/py36.yml" -p "${current_dir}/environments/py36" $@
 
 echo "Creating py36_editable environment"
 py36_editable="${current_dir}/environments/py36_editable"
-conda env create --force -f "${current_dir}/env_yamls/py36.yml" -p $py36_editable
+conda env create -f "${current_dir}/env_yamls/py36.yml" -p $py36_editable $@
 source activate $py36_editable
 pushd "${current_dir}/.." && python setup.py develop && popd
 source deactivate
 
 echo "Creating py36_broken environment"
-conda env create --force -f "${current_dir}/env_yamls/py36_broken.yml" -p "${current_dir}/environments/py36_broken"
+conda env create -f "${current_dir}/env_yamls/py36_broken.yml" -p "${current_dir}/environments/py36_broken" $@
 
 echo "Creating nopython environment"
-conda env create --force -f "${current_dir}/env_yamls/nopython.yml" -p "${current_dir}/environments/nopython"
+conda env create -f "${current_dir}/env_yamls/nopython.yml" -p "${current_dir}/environments/nopython" $@
+
+echo "Creating conda environment"
+conda env create -f "${current_dir}/env_yamls/has_conda.yml" -p "${current_dir}/environments/has_conda" $@


### PR DESCRIPTION
Allows conda to be a package installed in the environment, and makes the packaged environment work with conda after unpacking. Also allows the root environment to be packaged (although there may be more files we'll want to add to `ignore`).

Note that this still doesn't play well with conda-proper's activate/deactivate scripts since we replace them with our own. Both `conda activate environment` and `source activate environment` will work, but `source deactivate` afterwards will leave the environment variables in a bit of a broken state. Since the environment variables used to manage conda's state during activate/deactivate cycles are internal I'm not sure if it'd be wise to mimic those. `source environment/bin/activate` followed by `source deactivate` will continue to work as expected.

Fixes #32.

TODO:

- [x] Tests