### PR TITLE
Allow specifying destination prefix before packing

### DIFF
--- a/conda_pack/cli.py
+++ b/conda_pack/cli.py
@@ -44,6 +44,11 @@ def build_parser():
                         metavar="PATH", default='',
                         help=("The relative path in the archive to the conda "
                               "environment. Defaults to ''."))
+    parser.add_argument("--dest-prefix", "-d",
+                        metavar="PATH",
+                        help=("If present, prefixes will be rewritten to this "
+                              "path before packaging. In this case the "
+                              "`conda-unpack` script will not be generated."))
     parser.add_argument("--format",
                         choices=['infer', 'zip', 'tar.gz', 'tgz', 'tar.bz2',
                                  'tbz2', 'tar'],
@@ -124,6 +129,7 @@ def main(args=None, pack=pack):
                  zip_symlinks=args.zip_symlinks,
                  zip_64=not args.no_zip_64,
                  arcroot=args.arcroot,
+                 dest_prefix=args.dest_prefix,
                  verbose=not args.quiet,
                  filters=args.filters)
     except CondaPackException as e:

--- a/docs/source/spark.rst
+++ b/docs/source/spark.rst
@@ -4,17 +4,17 @@ Usage with Apache Spark on YARN
 ``conda-pack`` can be used to distribute conda environments to be used with
 `Apache Spark <http://spark.apache.org/>`_ jobs when `deploying on Apache YARN
 <http://spark.apache.org/docs/latest/running-on-yarn.html>`_. By bundling your
-environment for use with PySpark, you can make use of all the libraries
-provided by ``conda``, and ensure that their consistently provided on every
-node. This makes use of `YARN's
+environment for use with Spark, you can make use of all the libraries provided
+by ``conda``, and ensure that they're consistently provided on every node. This
+makes use of `YARN's
 <https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/YARN.html>`_
 resource localization by distributing environments as archives, which are then
 automatically unarchived on every node. In this case either the ``tar.gz`` or
 ``zip`` formats must be used.
 
 
-Example
--------
+Python Example
+--------------
 
 Create an environment:
 
@@ -93,3 +93,98 @@ Or in YARN client mode:
     --deploy-mode client \
     --archives environment.tar.gz#environment \
     script.py
+
+
+You can also start a PySpark interactive session using the following:
+
+.. code-block:: bash
+
+    $ PYSPARK_DRIVER_PYTHON=`which python` \
+    PYSPARK_PYTHON=./environment/bin/python \
+    pyspark \
+    --conf spark.yarn.appMasterEnv.PYSPARK_PYTHON=./environment/bin/python \
+    --master yarn \
+    --deploy-mode client \
+    --archives environment.tar.gz#environment
+
+
+R Example
+---------
+
+Conda also supports R environments. Here we'll demonstrate creating and
+packaging an environment for use with `Sparklyr <http://spark.rstudio.com/>`__.
+Note that similar techniques also work with `SparkR
+<https://spark.apache.org/docs/latest/sparkr.html>`__.
+
+First, create an environment:
+
+.. code-block:: bash
+
+    $ conda create -y -n example r-sparklyr
+
+
+Activate the environment:
+
+.. code-block:: bash
+
+    $ conda activate example   # Older conda versions use `source activate` instead
+
+
+Package the environment into a ``tar.gz`` archive. Note the addition of the
+``-d ./environment`` flag. This tells ``conda-pack`` to rewrite the any
+prefixes to the path ``./environment`` (the relative path to the environment
+from the working directory on the YARN workers) before packaging. This is
+required for R, as the R executables have absolute paths hardcoded in them
+(whereas Python does not).
+
+.. code-block:: bash
+
+    $ conda pack -o environment.tar.gz -d ./environment
+    Collecting packages...
+    Packing environment at '/Users/jcrist/anaconda/envs/example' to 'environment.tar.gz'
+    [########################################] | 100% Completed | 21.8s
+
+
+Write an R script, for example:
+
+.. code-block:: r
+
+    library(sparklyr)
+
+    # Create a spark configuration
+    config <- spark_config()
+
+    # Specify that the packaged environment should be distributed
+    # and unpacked to the directory "environment"
+    config$spark.yarn.dist.archives <- "environment.tar.gz#environment"
+
+    # Specify the R command to use, as well as various R locations on the workers
+    config$spark.r.command <- "./environment/bin/Rscript"
+    config$sparklyr.apply.env.R_HOME <- "./environment/lib/R"
+    config$sparklyr.apply.env.RHOME <- "./environment"
+    config$sparklyr.apply.env.R_SHARE_DIR <- "./environment/lib/R/share"
+    config$sparklyr.apply.env.R_INCLUDE_DIR <- "./environment/lib/R/include"
+
+    # Create a spark context.
+    # You can also specify `master = "yarn-cluster"` for cluster mode.
+    sc <- spark_connect(master = "yarn-client", config = config)
+
+    # Use a user defined function, which requires a working R environment on
+    # every worker node. Since all R packages already exist on every node, we
+    # pass in ``packages = FALSE`` to avoid redistributing them.
+    sdf_copy_to(sc, iris) %>%
+        spark_apply(function(e) broom::tidy(lm(Petal_Length ~ Petal_Width, e)),
+                    packages = FALSE)
+
+
+Run the script.
+
+.. code-block:: bash
+
+    $ Rscript script.R
+    # Source:   table<sparklyr_tmp_12de794b4e2a> [?? x 5]
+    # Database: spark_connection
+      Sepal_Length Sepal_Width Petal_Length Petal_Width  Species
+      <chr>              <dbl>        <dbl>       <dbl>    <dbl>
+    1 (Intercept)         1.08       0.0730        14.8 4.04e-31
+    2 Petal_Width         2.23       0.0514        43.4 4.68e-86


### PR DESCRIPTION
This adds a new option `--dest-prefix` that allows specifying the
destination prefix before packing. In this case the prefixes are
rewritten before packing the environment, and the `conda-unpack` script
won't be generated.

This is useful for cases where you can't run the `conda-unpack` script
but know the destination path beforehand.

Todo:
- [x] Tests