### PR TITLE
Handling case if dependencies have symlink

### DIFF
--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -571,6 +571,8 @@ def load_files(prefix):
             continue
         elif isfile(join(prefix, fn)):
             res.add(fn)
+        elif islink(join(prefix, fn)):
+            res.add(fn)
         else:
             for root, dirs, files in os.walk(join(prefix, fn)):
                 root2 = relpath(root, prefix)


### PR DESCRIPTION
if conda package contains symlink, then conda-meta/*.json conatins  entry of symlink.
so while generating list of files of a prefix. symlink needs to added as separate file.

eg assume a conda package contains 
 a_bin -> ./bin/

now conda-meta/*json file have a entry corresponds to it

```
{
        "_path": "a_bin",
        "path_type": "softlink",
        "size_in_bytes": 4096
      }


```
but `load_files(prefix): `function returns set(a_bin/file1, a_bin/file2, a_bin/file3)  

hence if failed at targets.difference(all_files)

