### PR TITLE
[WIP] Support windows & packing sub-environments

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,27 +12,22 @@ platform:
     - x64
 
 install:
-    # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
-    - cmd: rmdir C:\cygwin /s /q
-
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+    - cmd: conda.exe config --set safety_checks disabled
     - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
-    # Add our channels.
-    - cmd: conda.exe config --set show_channel_urls true
-    - cmd: conda.exe config --remove channels defaults
-    - cmd: conda.exe config --add channels defaults
-    - cmd: conda.exe config --add channels conda-forge
+    # Create the test environments
+    - cmd: bash.exe testing/setup_envs.sh
 
-    # Configure the VM.
-    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
-    - cmd: run_conda_forge_build_setup
+    # Install the required packages
+    - cmd: conda.exe install --yes flake8 pytest
+    - cmd: pip.exe install .
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - conda.exe build conda.recipe --quiet
+    - py.test.exe conda_pack --runslow -s -vv

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,6 @@ platform:
 install:
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda.exe config --set safety_checks disabled
     - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,38 @@
+environment:
+
+  matrix:
+    - TARGET_ARCH: x64
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+
+
+# We always use a 64-bit machine, but can build x86 distributions
+# with the TARGET_ARCH variable.
+platform:
+    - x64
+
+install:
+    # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
+    - cmd: rmdir C:\cygwin /s /q
+
+    # Add path, activate `conda` and update conda.
+    - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+    - cmd: conda.exe update --yes --quiet conda
+
+    - cmd: set PYTHONUNBUFFERED=1
+
+    # Add our channels.
+    - cmd: conda.exe config --set show_channel_urls true
+    - cmd: conda.exe config --remove channels defaults
+    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels conda-forge
+
+    # Configure the VM.
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
+    - cmd: run_conda_forge_build_setup
+
+# Skip .NET project specific build phase.
+build: off
+
+test_script:
+    - conda.exe build conda.recipe --quiet

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -6,9 +6,11 @@ source:
   path: ../
 
 build:
-  number: 1
+  number: 2
   script: python setup.py install --single-version-externally-managed --record=record.txt
   noarch: python
+  entry_points:
+    - conda-pack = conda_pack.cli:main
 
 requirements:
   build:
@@ -18,6 +20,8 @@ requirements:
     - python
 
 test:
+  commands:
+    - conda-pack --version
   imports:
     - conda_pack
 

--- a/conda_pack/cli.py
+++ b/conda_pack/cli.py
@@ -87,6 +87,9 @@ def build_parser():
                         metavar="PATTERN",
                         dest="filters",
                         help="Re-add excluded files matching this pattern")
+    parser.add_argument("--recursive",
+                        action="store_true",
+                        help="Additional environments if the prefix is a root environment")
     parser.add_argument("--force", "-f",
                         action="store_true",
                         help="Overwrite any existing archive at the output path.")
@@ -131,7 +134,8 @@ def main(args=None, pack=pack):
                  arcroot=args.arcroot,
                  dest_prefix=args.dest_prefix,
                  verbose=not args.quiet,
-                 filters=args.filters)
+                 filters=args.filters,
+                 recursive=args.recursive)
     except CondaPackException as e:
         fail("CondaPackError: %s" % e)
     except KeyboardInterrupt as e:

--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -927,6 +927,20 @@ class Packer(object):
         self.prefixes = []
 
     def add(self, file):
+        # Windows note:
+        # When adding files to an archive, that archive is generally case-sensitive.
+        # The target paths can be mixed case, and that means that they will be distinct
+        # directories in the archive.
+        #
+        # If those files are then extracted onto a case-sensitive file-system (such as a
+        # network share), Windows will not be able to traverse them correctly.
+        #
+        # The simple (undesirable) solution is to normalize (lowercase) the filenames when
+        # adding them to the archive.
+        # A nicer solution would be to note the "canonical" capitalization of a prefix when
+        # it first occurs, and use that every time the prefix occurs subsequently.
+        # 
+        # We just ignore this problem for the time being.
         if file.file_mode is None:
             if fnmatch(file.target, 'conda-meta/*.json'):
                 self.archive.add_bytes(file.source,

--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -364,7 +364,7 @@ class File(object):
     def __init__(self, source, target, is_conda=True, file_mode=None,
                  prefix_placeholder=None):
         self.source = source
-        self.target = os.path.normpath(target)
+        self.target = target
         self.is_conda = is_conda
         self.file_mode = file_mode
         self.prefix_placeholder = prefix_placeholder
@@ -696,9 +696,9 @@ def load_managed_package(info, prefix, site_packages):
                      for p in paths]
 
     if noarch_type == 'python':
-        seen = {i.target for i in files}
+        seen = {os.path.normcase(i.target) for i in files}
         for fil in info['files']:
-            if os.path.normpath(fil) not in seen:
+            if os.path.normcase(fil) not in seen:
                 file_mode = 'unknown' if fil.startswith(BIN_DIR) else None
                 f = File(os.path.join(prefix, fil), fil, is_conda=True,
                          prefix_placeholder=None, file_mode=file_mode)
@@ -748,7 +748,7 @@ def load_environment(prefix, on_missing_cache='warn'):
         # Check that no editable packages are installed
         check_no_editable_packages(prefix, site_packages)
 
-    all_files = load_files(prefix)
+    all_files = {os.path.normcase(p) for p in load_files(prefix)}
 
     files = []
     managed = set()
@@ -770,7 +770,7 @@ def load_environment(prefix, on_missing_cache='warn'):
             else:
                 new_files = load_managed_package(info, prefix, site_packages)
 
-            targets = {f.target for f in new_files}
+            targets = {os.path.normcase(f.target) for f in new_files}
 
             if targets.difference(all_files):
                 # Collect packages missing files as we progress to provide a

--- a/conda_pack/tests/test_cli.py
+++ b/conda_pack/tests/test_cli.py
@@ -10,6 +10,7 @@ import pytest
 
 import conda_pack
 from conda_pack.cli import main
+from conda_pack.compat import on_win
 
 from .conftest import py36_path, py27_path
 
@@ -128,6 +129,7 @@ def test_cli_warnings(capsys, broken_package_cache, tmpdir):
     assert "UserWarning" not in err  # printed, not from python warning
 
 
+@pytest.mark.skipif(on_win, reason='SIGINT terminates the tests on Windows')
 def test_keyboard_interrupt(capsys, tmpdir):
     def interrupt():
         time.sleep(0.5)

--- a/conda_pack/tests/test_core.py
+++ b/conda_pack/tests/test_core.py
@@ -157,28 +157,28 @@ def test_loaded_file_properties(py36_env):
 
 @pytest.mark.skipif(not on_win, reason='Different filenames and paths on Windows')
 def test_loaded_file_properties_win(py36_env):
-    lk = {f.target: f for f in py36_env}
+    lk = {os.path.normcase(f.target): f for f in py36_env}
 
     # Pip installed entrypoint
-    fil = lk[r'Scripts\pytest.exe']
+    fil = lk[r'scripts\pytest.exe']
     assert not fil.is_conda
     assert fil.file_mode == 'unknown'
     assert fil.prefix_placeholder is None
 
     # Conda installed noarch entrypoint
-    fil = lk[r'Scripts\conda-pack-test-lib1']
+    fil = lk[r'scripts\conda-pack-test-lib1']
     assert fil.is_conda
     assert fil.file_mode == 'text'
     assert fil.prefix_placeholder != py36_env.prefix
 
     # Conda installed entrypoint
-    fil = lk[r'Scripts\conda-pack-test-lib2.exe']
+    fil = lk[r'scripts\conda-pack-test-lib2.exe']
     assert fil.is_conda
     assert fil.file_mode == None
     assert fil.prefix_placeholder != py36_env.prefix
 
     # Conda installed file
-    fil = lk[r'Lib\site-packages\conda_pack_test_lib1\cli.py']
+    fil = lk[r'lib\site-packages\conda_pack_test_lib1\cli.py']
     assert fil.is_conda
     assert fil.file_mode is None
     assert fil.prefix_placeholder is None
@@ -403,8 +403,8 @@ def test_pack(tmpdir, py36_env):
                 .include(include))
 
     # Files line up with filtering, with extra conda-unpack command
-    sol = set(f.target for f in filtered.files)
-    res = set(os.path.normpath(p) for p in paths)
+    sol = set(os.path.normcase(f.target) for f in filtered.files)
+    res = set(os.path.normcase(p) for p in paths)
     diff = res.difference(sol)
 
     if on_win:
@@ -438,7 +438,7 @@ def test_dest_prefix(tmpdir, py36_env):
     # shebangs are rewritten using env
     with tarfile.open(out_path) as fil:
         text_from_conda = fil.extractfile('/'.join([BIN_DIR, 'conda-pack-test-lib1'])).read()
-        text_from_pip = fil.extractfile('Scripts/pytest.exe' if on_win else 'bin/pytest').read()
+        text_from_pip = fil.extractfile('scripts/pytest.exe' if on_win else 'bin/pytest').read()
 
     assert dest_bytes not in text_from_conda
     assert dest_bytes not in text_from_pip

--- a/conda_pack/tests/test_formats.py
+++ b/conda_pack/tests/test_formats.py
@@ -7,6 +7,10 @@ from subprocess import check_output, STDOUT
 import pytest
 
 from conda_pack.formats import archive
+from conda_pack.compat import on_win
+
+
+pytestmark = pytest.mark.skipif(on_win, reason='symlink not supported on Windows')
 
 
 @pytest.fixture(scope="module")

--- a/testing/env_yamls/py36_broken.yml
+++ b/testing/env_yamls/py36_broken.yml
@@ -8,4 +8,3 @@ dependencies:
     - toolz
     - pip:
         - toolz==0.7.0
-        - cytoolz==0.7.0


### PR DESCRIPTION
cc @mcg1969 @jcrist 

This is a work in progress PR to support packing environments on Windows. It also includes packing sub environments when packing a Miniconda/Anaconda installation with the `--recursive` flag (this could be factored out into a separate PR for easier review).

I've tested so far using it with a `--dest-prefix`, but I haven't got the scripts yet for when it's not relocated. Working on that now.

I've set up CI on Appveyor here: https://ci.appveyor.com/project/dsludwig/conda-pack