### PR TITLE
Skip fixing prefix in python exe in conda-unpack

### DIFF
--- a/conda_pack/compat.py
+++ b/conda_pack/compat.py
@@ -5,12 +5,22 @@ on_win = sys.platform == 'win32'
 
 
 if sys.version_info.major == 2:
+    from imp import load_source
+
     def source_from_cache(path):
         if path.endswith('.pyc') or path.endswith('.pyo'):
             return path[:-1]
         raise ValueError("Path %s is not a python bytecode file" % path)
 else:
+    import importlib
     from importlib.util import source_from_cache
+
+    def load_source(name, path):
+        loader = importlib.machinery.SourceFileLoader(name, path)
+        spec = importlib.util.spec_from_loader(loader.name, loader)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
 
 
 def find_py_source(path, ignore=True):

--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -956,13 +956,18 @@ class Packer(object):
 
         if not on_win:
             shebang = '#!/usr/bin/env python'
+            python_pattern = re.compile(os.path.join(BIN_DIR, 'python\d.\d'))
         else:
             shebang = ('@SETLOCAL ENABLEDELAYEDEXPANSION & CALL "%~f0" & (IF '
                        'NOT ERRORLEVEL 1 (python -x "%~f0" %*) ELSE (ECHO No '
                        'python environment found on path)) & PAUSE & EXIT /B '
                        '!ERRORLEVEL!')
+            python_pattern = re.compile(os.path.join(BIN_DIR, 'python'))
 
-        prefix_records = ',\n'.join(repr(p) for p in self.prefixes)
+        # We skip prefix rewriting in python executables (if needed)
+        # to avoid editing a running file.
+        prefix_records = ',\n'.join(repr(p) for p in self.prefixes
+                                    if not python_pattern.match(p[0]))
 
         with open(os.path.join(_current_dir, 'prefixes.py')) as fil:
             prefixes_py = fil.read()

--- a/conda_pack/tests/test_core.py
+++ b/conda_pack/tests/test_core.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, division
 
 import json
 import os
+import re
 import subprocess
 import tarfile
 from glob import glob
@@ -10,6 +11,7 @@ import pytest
 
 from conda_pack import CondaEnv, CondaPackException, pack
 from conda_pack.core import name_to_prefix, File
+from conda_pack.compat import load_source
 
 from .conftest import (py36_path, py36_editable_path, py36_broken_path,
                        py27_path, nopython_path, has_conda_path, rel_env_dir,
@@ -237,6 +239,13 @@ def test_roundtrip(tmpdir, py36_env):
     out = subprocess.check_output([conda_unpack, '--version'],
                                   stderr=subprocess.STDOUT).decode()
     assert out.startswith('conda-unpack')
+
+    # Check no prefix generated for python executable
+    python_pattern = re.compile('bin/python\d.\d')
+    conda_unpack_mod = load_source('conda_unpack', conda_unpack)
+    pythons = [r for r in conda_unpack_mod._prefix_records
+               if python_pattern.match(r[0])]
+    assert not pythons
 
     # Check bash scripts all don't error
     command = (". {path}/bin/activate && "


### PR DESCRIPTION
On Linux rewriting a running executable file is forbidden. Python is
required for running `conda-unpack`, and *some* versions of python have
an absolute path in them - this can cause problems when the packaged
python is the one running the `conda-unpack` script.

Since the absolute path embedded in the python binary is not important
for normal use, we skip rewriting it when run from `conda-unpack` -
avoiding the issue entirely. Note that we still rewrite the prefix when
using a specified destination prefix.

Fixes #47.