### PR TITLE
Keep conda's activate/deactivate scripts

### DIFF
--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -705,10 +705,14 @@ def load_environment(prefix, on_missing_cache='warn'):
     managed = set()
     uncached = []
     missing_files = []
+    conda_in_env = False
     for path in os.listdir(conda_meta):
         if path.endswith('.json'):
             with open(os.path.join(conda_meta, path)) as fil:
                 info = json.load(fil)
+            if info['name'] == 'conda':
+                conda_in_env = True
+
             pkg = info['link']['source']
 
             if not os.path.exists(pkg):
@@ -762,8 +766,9 @@ def load_environment(prefix, on_missing_cache='warn'):
                       file_mode='unknown')
                  for p in unmanaged if not find_py_source(p) in managed)
 
-    # Override activate/deactivate scripts
-    files.extend(File(*s) for s in _scripts)
+    # Add activate/deactivate scripts to non-conda envs
+    if not conda_in_env:
+        files.extend(File(*s) for s in _scripts)
 
     if uncached and on_missing_cache in ('warn', 'raise'):
         packages = '\n'.join('- %s=%r   %s' % i for i in uncached)

--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -891,7 +891,8 @@ class Packer(object):
         # We just ignore this problem for the time being.
         if file.file_mode is None:
             if fnmatch(file.target, 'conda-meta/*.json'):
-                if file.target.rsplit('-', 2)[0] == 'conda':
+                # Detect if conda is installed
+                if os.path.basename(file.target).rsplit('-', 2)[0] == 'conda':
                     self.has_conda = True
                 self.archive.add_bytes(file.source,
                                        rewrite_conda_meta(file.source),

--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -766,8 +766,10 @@ def load_environment(prefix, on_missing_cache='warn'):
                       file_mode='unknown')
                  for p in unmanaged if not find_py_source(p) in managed)
 
-    # Add activate/deactivate scripts to non-conda envs
-    if not conda_in_env:
+    # Add activate/deactivate scripts to non-conda envs, but only if the
+    # destination prefix is given. We'll need to do a little more work to
+    # get this working in the general case.
+    if not (self.has_dest and conda_in_env):
         files.extend(File(*s) for s in _scripts)
 
     if uncached and on_missing_cache in ('warn', 'raise'):

--- a/conda_pack/tests/test_core.py
+++ b/conda_pack/tests/test_core.py
@@ -127,12 +127,6 @@ def test_load_environment_ignores(py36_env):
     for path in ['{}/conda'.format(BIN_DIR_L), 'conda-meta']:
         assert path not in lk
 
-    # activate/deactivate exist, but aren't from conda
-    bat_suffix = '.bat' if on_win else ''
-    for file in ('activate', 'deactivate'):
-        fname = '{}/{}{}'.format(BIN_DIR_L, file, bat_suffix)
-        assert not lk[fname].source.startswith(py36_path)
-
 
 def test_file():
     f = File('/root/path/to/foo/bar', 'foo/bar')
@@ -183,7 +177,6 @@ def test_include_exclude(py36_env):
     # No mutation
     assert len(py36_env) == old_len
     assert env2 is not py36_env
-
     assert len(env2) < len(py36_env)
 
     # Re-add the removed files, envs are equivalent
@@ -423,12 +416,12 @@ def test_pack(tmpdir, py36_env):
     diff = res.difference(sol)
 
     if on_win:
-        # conda-unpack.exe and conda-unpack-script.py
-        assert len(diff) == 2
+        assert diff == {'{}/{}'.format(BIN_DIR_L, extra)
+                        for extra in ('conda-unpack', 'conda-unpack-script',
+                                      'activate', 'deactivate')}
     else:
-        assert len(diff) == 1
-    extra = list(diff)[0]
-    assert 'conda-unpack' in extra
+        assert diff == {'{}/{}'.format(BIN_DIR_L, extra)
+                        for extra in ('conda-unpack', 'activate', 'deactivate')}
 
 
 def test_dest_prefix(tmpdir, py36_env):

--- a/conda_pack/tests/test_core.py
+++ b/conda_pack/tests/test_core.py
@@ -121,6 +121,15 @@ def test_env_properties(py36_env):
     assert 'CondaEnv<' in repr(py36_env)
 
 
+def test_load_environment_ignores(py36_env):
+    lk = {normpath(f.target): f for f in py36_env}
+    for fname in ('conda', 'conda.bat'):
+        assert '{}/{}'.format(BIN_DIR_L, fname) not in lk
+    for fname in ('activate', 'activate.bat', 'deactivate', 'deactivate.bat'):
+        fpath = '{}/{}'.format(BIN_DIR_L, fname)
+        assert fpath not in lk or not lk[fpath].source.startswith(py36_path)
+
+
 def test_file():
     f = File('/root/path/to/foo/bar', 'foo/bar')
     # smoketest repr

--- a/conda_pack/tests/test_core.py
+++ b/conda_pack/tests/test_core.py
@@ -279,12 +279,13 @@ def test_roundtrip(tmpdir, py36_env):
         assert out == 'Done\n'
 
 
-def test_pack_with_conda(tmpdir):
+@pytest.mark.parametrize('fix_dest', (True, False))
+def test_pack_with_conda(tmpdir, fix_dest):
     env = CondaEnv.from_prefix(has_conda_path)
     out_path = os.path.join(str(tmpdir), 'has_conda.tar')
-    env.pack(out_path)
-
     extract_path = os.path.join(str(tmpdir), 'output')
+    env.pack(out_path, dest_prefix=extract_path if fix_dest else None)
+
     os.mkdir(extract_path)
 
     assert os.path.exists(out_path)

--- a/conda_pack/tests/test_core.py
+++ b/conda_pack/tests/test_core.py
@@ -417,12 +417,11 @@ def test_pack(tmpdir, py36_env):
     diff = res.difference(sol)
 
     if on_win:
-        assert diff == {'{}/{}'.format(BIN_DIR_L, extra)
-                        for extra in ('conda-unpack', 'conda-unpack-script',
-                                      'activate', 'deactivate')}
+        fnames = ('conda-unpack.exe', 'conda-unpack-script.py',
+                  'activate.bat', 'deactivate.bat')
     else:
-        assert diff == {'{}/{}'.format(BIN_DIR_L, extra)
-                        for extra in ('conda-unpack', 'activate', 'deactivate')}
+        fnames = ('conda-unpack', 'activate', 'deactivate')
+    assert diff == set(os.path.join(BIN_DIR_L, f) for f in fnames)
 
 
 def test_dest_prefix(tmpdir, py36_env):

--- a/testing/setup_envs.sh
+++ b/testing/setup_envs.sh
@@ -8,6 +8,19 @@ conda env create -f "${current_dir}/env_yamls/py27.yml" -p "${current_dir}/envir
 
 echo "Creating py36 environment"
 conda env create -f "${current_dir}/env_yamls/py36.yml" -p "${current_dir}/environments/py36" $@
+# Create unmanaged conda-related files for conda-pack to remove
+if [[ "$OS" == "Windows_NT" ]]; then
+	touch ${current_dir}/environments/py36/Scripts/activate
+	touch ${current_dir}/environments/py36/Scripts/activate.bat
+	touch ${current_dir}/environments/py36/Scripts/deactivate
+	touch ${current_dir}/environments/py36/Scripts/deactivate.bat
+	touch ${current_dir}/environments/py36/Scripts/conda
+	touch ${current_dir}/environments/py36/Scripts/conda.bat
+else
+	touch ${current_dir}/environments/py36/bin/activate
+	touch ${current_dir}/environments/py36/bin/deactivate
+	touch ${current_dir}/environments/py36/bin/conda
+fi
 
 echo "Creating py36_editable environment"
 py36_editable="${current_dir}/environments/py36_editable"


### PR DESCRIPTION
_Builds on #54._

If the environment being packed up contains conda, we shouldn't replace the activate/deactivate scripts. The `conda-pack` scripts are not designed to support the activation of sub-environments, only the root. If `conda` is present, then presumably users of that environment might wish to use it to create and activate new sub-environments.
