### PR TITLE
Cleanup setup.py/setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,6 @@ versionfile_source = conda_pack/_version.py
 versionfile_build = conda_pack/_version.py
 tag_prefix =
 parentdir_prefix = conda-pack-
+
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,5 @@
 from setuptools import setup
 import versioneer
-import sys
-
-is_win = sys.platform.startswith('win')
 
 setup(name='conda-pack',
       version=versioneer.get_version(),
@@ -25,11 +22,10 @@ setup(name='conda-pack',
       description='Package conda environments for redistribution',
       long_description=open('README.rst').read(),
       packages=['conda_pack'],
-      # We need to install both here so noarch packages build properly
-      package_data={'conda_pack': ['scripts/windows/*',
-                                   'scripts/posix/*']},
+      package_data={'conda_pack': ['scripts/windows/*', 'scripts/posix/*']},
       entry_points='''
         [console_scripts]
         conda-pack=conda_pack.cli:main
       ''',
+      install_requires=['setuptools'],
       zip_safe=False)


### PR DESCRIPTION
With the new windows support, we needed a few changes to these files
before release.

- Depend on setuptools
- Can now build a universal wheel