### PR TITLE
Add zstandard support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
   - source testing/ci/install_conda.sh
   - ./testing/setup_envs.sh
   - conda install -y flake8 pytest
+  - pip install zstandard
   - |
     if [[ "$DOCS" == "true" ]]; then
         conda install -y sphinx numpydoc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ install:
 
     # Install the required packages
     - cmd: conda.exe install --yes flake8 pytest
+    - cmd: pip.exe install zstandard
     - cmd: pip.exe install .
 
     # Create the test environments. Do this after install

--- a/conda_pack/cli.py
+++ b/conda_pack/cli.py
@@ -51,7 +51,7 @@ def build_parser():
                               "`conda-unpack` script will not be generated."))
     parser.add_argument("--format",
                         choices=['infer', 'zip', 'tar.gz', 'tgz', 'tar.bz2',
-                                 'tbz2', 'tar'],
+                                 'tbz2', 'tar.zst', 'tzst', 'tar'],
                         default='infer',
                         help=("The archival format to use. By default this is "
                               "inferred by the output file extension."))


### PR DESCRIPTION
This uses the python zstandard library to add optional zstandard compression support. I chose this library over libarchive due to simpler dependency chain and higher community acceptance (larger contributor/user base). This PR is also simpler than #53.

Supersedes #53.