### PR TITLE
Add support for parallel packaging

### DIFF
--- a/conda_pack/_progress.py
+++ b/conda_pack/_progress.py
@@ -51,7 +51,7 @@ class progressbar(object):
     def __init__(self, iterable, width=40, enabled=True, file=None):
         self._iterable = iterable
         self._ndone = 0
-        self._ntotal = len(iterable)
+        self._ntotal = len(iterable) + 1  # wait for exit to finish
         self._width = width
         self._enabled = enabled
         self._file = sys.stdout if file is None else file
@@ -70,6 +70,8 @@ class progressbar(object):
         if self._enabled:
             self._running = False
             self._timer.join()
+            if type is None:  # Finished if no exception
+                self._ndone += 1
             self._update_bar()
             self._file.write('\n')
             self._file.flush()

--- a/conda_pack/cli.py
+++ b/conda_pack/cli.py
@@ -56,12 +56,21 @@ def build_parser():
                         help=("The archival format to use. By default this is "
                               "inferred by the output file extension."))
     parser.add_argument("--compress-level",
+                        metavar="LEVEL",
                         type=int,
                         default=4,
                         help=("The compression level to use, from 0 to 9. "
                               "Higher numbers decrease output file size at "
                               "the expense of compression time. Ignored for "
                               "``format='zip'``. Default is 4."))
+    parser.add_argument("--n-threads", "-j",
+                        metavar="N",
+                        type=int,
+                        default=1,
+                        help=("The number of threads to use. Set to -1 to use "
+                              "the number of cpus on this machine. If a file "
+                              "format doesn't support threaded packaging, this "
+                              "option will be ignored. Default is 1."))
     parser.add_argument("--zip-symlinks",
                         action="store_true",
                         help=("Symbolic links aren't supported by the Zip "
@@ -126,6 +135,7 @@ def main(args=None, pack=pack):
                  format=args.format,
                  force=args.force,
                  compress_level=args.compress_level,
+                 n_threads=args.n_threads,
                  zip_symlinks=args.zip_symlinks,
                  zip_64=not args.no_zip_64,
                  arcroot=args.arcroot,

--- a/conda_pack/compat.py
+++ b/conda_pack/compat.py
@@ -3,9 +3,12 @@ import sys
 default_encoding = sys.getdefaultencoding()
 on_win = sys.platform == 'win32'
 
+PY2 = sys.version_info.major == 2
 
-if sys.version_info.major == 2:
+
+if PY2:
     from imp import load_source
+    from Queue import Queue
 
     def source_from_cache(path):
         if path.endswith('.pyc') or path.endswith('.pyo'):
@@ -14,6 +17,7 @@ if sys.version_info.major == 2:
 else:
     import importlib
     from importlib.util import source_from_cache
+    from queue import Queue  # noqa
 
     def load_source(name, path):
         loader = importlib.machinery.SourceFileLoader(name, path)

--- a/conda_pack/formats.py
+++ b/conda_pack/formats.py
@@ -1,32 +1,202 @@
+from __future__ import print_function, division, absolute_import
+
+import bz2
+import gzip
 import os
 import stat
+import struct
 import sys
 import tarfile
+import threading
 import time
 import zipfile
+import zlib
+
+from contextlib import closing
 from io import BytesIO
 
-_tar_mode = {'tar.gz': 'w:gz',
-             'tgz': 'w:gz',
-             'tar.bz2': 'w:bz2',
-             'tbz2': 'w:bz2',
-             'tar': 'w'}
+from .core import CondaPackException
+
+
+def _parse_n_threads(n_threads=1):
+    if n_threads == -1:
+        from multiprocessing import cpu_count
+        return cpu_count()
+    if n_threads < 1:
+        raise CondaPackException("n-threads must be >= 1, or -1 for all cores")
+    return n_threads
 
 
 def archive(fileobj, arcroot, format, compress_level=4, zip_symlinks=False,
-            zip_64=True):
+            zip_64=True, n_threads=1):
+
+    n_threads = _parse_n_threads(n_threads)
+
     if format == 'zip':
         return ZipArchive(fileobj, arcroot, zip_symlinks=zip_symlinks,
                           zip_64=zip_64)
-    else:
-        return TarArchive(fileobj, arcroot, _tar_mode[format],
-                          compress_level=compress_level)
+
+    # Tar archives
+    close_file = True
+    if format in ('tar.gz', 'tgz'):
+        if n_threads == 1:
+            fileobj = gzip.GzipFile(fileobj=fileobj, compresslevel=compress_level,
+                                    mode='wb')
+        else:
+            fileobj = ParallelGzipFileWriter(fileobj, compresslevel=compress_level,
+                                             n_threads=n_threads)
+    elif format in ('tar.bz2', 'tbz2'):
+        if n_threads == 1:
+            fileobj = bz2.BZ2File(fileobj, compresslevel=compress_level, mode='wb')
+        else:
+            fileobj = ParallelBZ2FileWriter(fileobj, compresslevel=compress_level,
+                                            n_threads=n_threads)
+    else:  # format == 'tar'
+        close_file = False
+    return TarArchive(fileobj, arcroot, close_file=close_file)
+
+
+class ParallelFileWriter(object):
+    def __init__(self, fileobj, compresslevel=9, n_threads=1):
+        self.fileobj = fileobj
+        self.compresslevel = compresslevel
+        self.n_threads = n_threads
+
+        # Initialize file state
+        self.size = 0
+        self._init_state()
+        self._write_header()
+
+        # Parallel initialization
+        self.buffers = []
+        self.buffer_length = 0
+
+        from multiprocessing.pool import ThreadPool
+        from queue import Queue
+        self.pool = ThreadPool(n_threads)
+        self.compress_queue = Queue(maxsize=n_threads)
+
+        self._consumer_thread = threading.Thread(target=self._consumer)
+        self._consumer_thread.daemon = True
+        self._consumer_thread.start()
+
+    def tell(self):
+        return self.size
+
+    def write(self, data):
+        if not isinstance(data, bytes):
+            data = memoryview(data)
+        n = len(data)
+        if n > 0:
+            self._per_buffer_op(data)
+            self.size += n
+            self.buffer_length += n
+            self.buffers.append(data)
+            if self.buffer_length > self._block_size:
+                self.compress_queue.put(self.buffers)
+                self.buffers = []
+                self.buffer_length = 0
+        return n
+
+    def _consumer(self):
+        with closing(self.pool):
+            for buffers in self.pool.imap(
+                    self._compress, iter(self.compress_queue.get, None)):
+                for buf in buffers:
+                    if len(buf):
+                        self.fileobj.write(buf)
+
+    def _compress(self, in_bufs):
+        out_bufs = []
+        compressor = self._new_compressor()
+        for data in in_bufs:
+            out_bufs.append(compressor.compress(data))
+        out_bufs.append(self._flush_compressor(compressor))
+        return out_bufs
+
+    def close(self):
+        if self.fileobj is None:
+            return
+
+        # Flush any waiting buffers
+        if self.buffers:
+            self.compress_queue.put(self.buffers)
+
+        # Wait for all work to finish
+        self.compress_queue.put(None)
+        self._consumer_thread.join()
+
+        # Write the closing bytes
+        self._write_footer()
+
+        # Flush fileobj
+        self.fileobj.flush()
+
+        # Cache shutdown state
+        self.compress_queue = None
+        self.pool = None
+        self.fileobj = None
+
+
+class ParallelGzipFileWriter(ParallelFileWriter):
+    # Since it's hard for us to keep a running dictionary (a serial operation)
+    # with parallel compression of blocks, we use a blocksize > a few factors
+    # bigger than the max dict size (32 KiB). In practice this is fine - we
+    # only lose out by a small factor of unneeded redundancy, and real files
+    # often lack enough redundant byte sequences to make this significant. Pigz
+    # uses 128 KiB, but does more work to keep a running dict.
+    _block_size = 256 * 2**10
+
+    def _init_state(self):
+        self.crc = zlib.crc32(b"")
+
+    def _new_compressor(self):
+        return zlib.compressobj(self.compresslevel, zlib.DEFLATED,
+                                -zlib.MAX_WBITS, zlib.DEF_MEM_LEVEL, 0)
+
+    def _per_buffer_op(self, buffer):
+        self.crc = zlib.crc32(buffer, self.crc)
+
+    def _write32u(self, value):
+        self.fileobj.write(struct.pack("<L", value))
+
+    def _write_header(self):
+        self.fileobj.write(b'\037\213\010')
+        self.fileobj.write(b'\x00')
+        self._write32u(int(time.time()))
+        self.fileobj.write(b'\002\377')
+
+    def _write_footer(self):
+        self.fileobj.write(self._new_compressor().flush(zlib.Z_FINISH))
+        self._write32u(self.crc)
+        self._write32u(self.size & 0xffffffff)
+
+    def _flush_compressor(self, compressor):
+        return compressor.flush(zlib.Z_FULL_FLUSH)
+
+
+class ParallelBZ2FileWriter(ParallelFileWriter):
+    def _init_state(self):
+        # bzip2 compresslevel dictates its blocksize of 100 - 900 kb
+        self._block_size = self.compresslevel * 100 * 2**10
+
+    def _new_compressor(self):
+        return bz2.BZ2Compressor(self.compresslevel)
+
+    def _per_buffer_op(self, buffer):
+        pass
+
+    def _write_header(self):
+        pass
+
+    def _write_footer(self):
+        pass
+
+    def _flush_compressor(self, compressor):
+        return compressor.flush()
 
 
 class ArchiveBase(object):
-    def __exit__(self, *args):
-        self.archive.close()
-
     def add(self, source, target):
         target = os.path.join(self.arcroot, target)
         self._add(source, target)
@@ -37,21 +207,20 @@ class ArchiveBase(object):
 
 
 class TarArchive(ArchiveBase):
-    def __init__(self, fileobj, arcroot, mode, compress_level):
+    def __init__(self, fileobj, arcroot, close_file=False):
         self.fileobj = fileobj
         self.arcroot = arcroot
-        self.mode = mode
-        self.compress_level = compress_level
+        self.close_file = close_file
 
     def __enter__(self):
-        if self.mode != 'w':
-            kwargs = {'compresslevel': self.compress_level}
-        else:
-            kwargs = {}
-
-        self.archive = tarfile.open(fileobj=self.fileobj, mode=self.mode,
-                                    dereference=False, **kwargs)
+        self.archive = tarfile.open(fileobj=self.fileobj, mode='w',
+                                    dereference=False)
         return self
+
+    def __exit__(self, *args):
+        self.archive.close()
+        if self.close_file:
+            self.fileobj.close()
 
     def _add(self, source, target):
         self.archive.add(source, target, recursive=False)
@@ -74,6 +243,13 @@ class ZipArchive(ArchiveBase):
                                        allowZip64=self.zip_64,
                                        compression=zipfile.ZIP_DEFLATED)
         return self
+
+    def __exit__(self, type, value, traceback):
+        self.archive.close()
+        if isinstance(value, zipfile.LargeZipFile):
+            raise CondaPackException(
+                "Large Zip File: ZIP64 extensions required "
+                "but were disabled")
 
     def _add(self, source, target):
         try:

--- a/conda_pack/tests/test_formats.py
+++ b/conda_pack/tests/test_formats.py
@@ -126,6 +126,8 @@ def has_infozip_cli():
 
 
 def has_tar_cli():
+    if on_win:
+        return False
     try:
         check_output(['tar', '-h'], stderr=STDOUT)
         return True


### PR DESCRIPTION
This adds support for parallelizing file compression for `.tar.gz` and `.tar.bz2` files. This scales ~linearly, and can provide major speedups for higher compression levels.

The default is still single threaded, but you can use `--n-threads`/`-j` to set the number of threads. `-1` indicates use the number of threads as cores.

Also fixes our test suite to test both with and without symlinks on all platorms (explicitly skipping where unsupported). This improves test coverage on my machine.