### PR TITLE
Handle noarch-python packages missing pyc files

### DIFF
--- a/testing/env_yamls/py27.yml
+++ b/testing/env_yamls/py27.yml
@@ -8,4 +8,8 @@ dependencies:
     - python=2.7
     - conda_pack_test_lib1
     - conda_pack_test_lib2
-    - toolz
+    # jinja2 is a noarch-python package that contains a few py3-only source
+    # files. The noarch logic in conda just adds a `.pyc` file for every `.py`
+    # file, but in this py2 env some of these paths won't actually exist due to
+    # bytecode compilation failure.
+    - jinja2


### PR DESCRIPTION
Some packages have files that will fail to bytecode compile on older
versions of python (e.g. optional py3-only features). When these files
are made noarch-python packages, some of them will fail to bytecode
compile (and thus won't exist), but conda still marks them as present
in the paths.json file. To correct for this, we now check for the
presence of every pyc file before adding it when collecting files. The
`jinja2` package exhibits this behavior, and valid packaging of an
environment with this package is used as a test.

Fixes #63.