### PR TITLE
Only (de)activate using *.sh

### DIFF
--- a/conda_pack/scripts/posix/activate
+++ b/conda_pack/scripts/posix/activate
@@ -56,7 +56,7 @@ _conda_pack_activate() {
     local _script_dir="${full_path_env}/etc/conda/activate.d"
     if [ -d "$_script_dir" ] && [ -n "$(ls -A "$_script_dir")" ]; then
         local _path
-        for _path in "$_script_dir"/*; do
+        for _path in "$_script_dir"/*.sh; do
             . "$_path"
         done
     fi

--- a/conda_pack/scripts/posix/deactivate
+++ b/conda_pack/scripts/posix/deactivate
@@ -5,7 +5,7 @@ _conda_pack_deactivate () {
         local _script_dir="${CONDA_PREFIX}/etc/conda/deactivate.d"
         if [ -d "$_script_dir" ] && [ -n "$(ls -A "$_script_dir")" ]; then
             local _path
-            for _path in "$_script_dir"/*; do
+            for _path in "$_script_dir"/*.sh; do
                 . "$_path"
             done
         fi


### PR DESCRIPTION
Currently everything in the environment scripts folder is ran but only `*.sh` files should be used when (de)activating environments ([see here](https://github.com/conda/conda/blob/8232664e43c323e8381ced751c4c80411f4ee4ee/conda/activate.py#L644-L652)).