### PR TITLE
Fixes for changes in conda 4.7

### DIFF
--- a/conda_pack/scripts/posix/activate
+++ b/conda_pack/scripts/posix/activate
@@ -36,7 +36,11 @@ _conda_pack_activate() {
     if [ -n "$CONDA_PREFIX" ]; then
         # If the source env differs from this env
         if [ "$CONDA_PREFIX" != "$full_path_env" ]; then
-            . deactivate
+            # Check whether deactivate is a function or executable
+            type deactivate >/dev/null
+            if [ $? -eq 0 ]; then
+                . deactivate >/dev/null 2>/dev/null
+            fi
         else
             return 0  # nothing to do
         fi

--- a/conda_pack/tests/test_core.py
+++ b/conda_pack/tests/test_core.py
@@ -330,7 +330,7 @@ def test_pack_with_conda(tmpdir, fix_dest):
         commands = ("unset CONDA_PREFIX",
                     ". {path}/bin/activate".format(path=extract_path),
                     "conda info --json",
-                    ". deactivate")
+                    ". deactivate >/dev/null 2>/dev/null")
         script_file = tmpdir.join('unpack.sh')
         cmd = ['/usr/bin/env', 'bash', str(script_file)]
 

--- a/testing/setup_envs.sh
+++ b/testing/setup_envs.sh
@@ -31,7 +31,8 @@ conda env create -f "${current_dir}/env_yamls/py36.yml" -p $py36_editable $@
 activation=`(type activate > /dev/null && echo 'source' ) || echo conda`
 $activation activate $py36_editable
 pushd "${current_dir}/.." && python setup.py develop && popd
-source deactivate
+deactivation=`(type deactivate > /dev/null && echo 'source' ) || echo conda`
+$deactivation deactivate
 
 echo "Creating py36_broken environment"
 conda env create -f "${current_dir}/env_yamls/py36_broken.yml" -p "${current_dir}/environments/py36_broken" $@

--- a/testing/setup_envs.sh
+++ b/testing/setup_envs.sh
@@ -1,4 +1,7 @@
 #/usr/bin/env bash
+
+set -eo pipefail
+
 echo "== Setting up environments for testing =="
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -25,7 +28,8 @@ fi
 echo "Creating py36_editable environment"
 py36_editable="${current_dir}/environments/py36_editable"
 conda env create -f "${current_dir}/env_yamls/py36.yml" -p $py36_editable $@
-source activate $py36_editable
+activation=`(type activate > /dev/null && echo 'source' ) || echo conda`
+$activation activate $py36_editable
 pushd "${current_dir}/.." && python setup.py develop && popd
 source deactivate
 


### PR DESCRIPTION
`activate` and `deactivate` still exist but not anymore always but only in certain situations. Use them when available.

This is only a partial fix for #76, `test_pack_with_conda[True]` still fails but this may be unrelated.