### PR TITLE
Don't drop LICENSE.txt

### DIFF
--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -568,9 +568,9 @@ def read_has_prefix(path):
 def load_files(prefix):
     from os.path import relpath, join, isfile, islink
 
-    ignore = {'pkgs', 'envs', 'conda-bld', '.conda_lock', 'users',
-              'LICENSE.txt', 'info', 'conda-recipes', '.index', '.unionfs',
-              '.nonadmin', 'python.app', 'Launcher.app'}
+    ignore = {'pkgs', 'envs', 'conda-bld', '.conda_lock', 'users', 'info',
+              'conda-recipes', '.index', '.unionfs', '.nonadmin', 'python.app',
+              'Launcher.app'}
 
     res = set()
 

--- a/conda_pack/scripts/posix/activate
+++ b/conda_pack/scripts/posix/activate
@@ -37,7 +37,7 @@ _conda_pack_activate() {
         # If the source env differs from this env
         if [ "$CONDA_PREFIX" != "$full_path_env" ]; then
             # Check whether deactivate is a function or executable
-            type deactivate >/dev/null
+            type deactivate >/dev/null 2>/dev/null
             if [ $? -eq 0 ]; then
                 . deactivate >/dev/null 2>/dev/null
             fi


### PR DESCRIPTION
Previously we'd ignore LICENSE.txt in the of an environment directory.
In previous conda versions this would be the anaconda license, but in
new releases this file doesn't normally exist. However, some packages
(e.g. tomopy) do include this file in their package (probably
erroneously, as LICENSE.txt in a root directory has nothing specific to
do with their package). By dropping it during collection our pip
clobbering detection logic would trigger, resulting in failure.

Also fixes a small bug in the posix activate script that resulted in
some noisy output.