### PR TITLE
extract the shebang from the binary file

### DIFF
--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import tempfile
 import warnings
+import struct
 from contextlib import contextmanager
 from fnmatch import fnmatch
 

--- a/conda_pack/prefixes.py
+++ b/conda_pack/prefixes.py
@@ -81,7 +81,7 @@ def replace_prefix(data, mode, placeholder, new_prefix):
         data2 = binary_replace(data,
                                placeholder.encode('utf-8'),
                                new_prefix.encode('utf-8'))
-        if len(data2) != len(data):
+        if len(data2) - len(new_prefix.encode('utf-8')) != len(data) - len(placeholder.encode('utf-8')):
             message = ("Found mismatched data length in binary file:\n"
                        "original data length: {len_orig!d})\n"
                        "new data length: {len_new!d}\n"


### PR DESCRIPTION
This addresses the issue #80. In the case of windows binaries which have unknown file mode, I extract the placeholder from the binary itself.