### PR TITLE
fix(#80): replace python path reference properly for binary files

### DIFF
--- a/conda_pack/prefixes.py
+++ b/conda_pack/prefixes.py
@@ -81,6 +81,9 @@ def replace_prefix(data, mode, placeholder, new_prefix):
         data2 = binary_replace(data,
                                placeholder.encode('utf-8'),
                                new_prefix.encode('utf-8'))
+        if on_win:
+            return data2
+
         if len(data2) != len(data):
             message = ("Found mismatched data length in binary file:\n"
                        "original data length: {len_orig!d})\n"
@@ -99,6 +102,8 @@ def text_replace(data, placeholder, new_prefix):
 
 if on_win:
     def binary_replace(data, placeholder, new_prefix):
+        placeholder = placeholder.lower()
+        new_prefix = new_prefix.lower()
         if placeholder not in data:
             return data
         return replace_pyzzer_entry_point_shebang(data, placeholder, new_prefix)


### PR DESCRIPTION
This PR apply comments discussed in issue  #80  and fixes it.
