### PR TITLE
Repack environment when needed

### DIFF
--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -880,7 +880,7 @@ if __name__ == '__main__':
     patch_path_file = os.path.join(new_prefix, "current_path_patch.bak")
 
     if args.version:
-        print('conda-unpack 0.4.0')
+        print('conda-unpack {version}')
     elif args.repack:
         with open(patch_path_file, 'w+') as fh:
             fh.write('')
@@ -893,7 +893,7 @@ if __name__ == '__main__':
                 fh.write('')
         with open(patch_path_file, 'r+') as fh:
             backup_prefix = fh.read()
-            print("backup path: {:s}, current path: {:s}".format(backup_prefix, new_prefix))
+            print('backup path: ' + backup_prefix +', current path: ' + new_prefix)
             if (backup_prefix != new_prefix and len(backup_prefix) > 0):
                 for path, placeholder, mode in _prefix_records:
                     update_prefix(os.path.join(new_prefix, path), new_prefix, backup_prefix, mode=mode)

--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -867,6 +867,9 @@ if __name__ == '__main__':
     parser.add_argument('--version',
                         action='store_true',
                         help='Show version then exit')
+    parser.add_argument('--repack', 
+                        action='store_true',
+                        help='restore relative paths for portability')
     args = parser.parse_args()
     # Manually handle version printing to output to stdout in python < 3.4
     if args.version:

--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -893,13 +893,14 @@ if __name__ == '__main__':
                 fh.write('')
         with open(patch_path_file, 'r+') as fh:
             backup_prefix = fh.read()
-            print('backup path: ' + backup_prefix +', current path: ' + new_prefix)
-            if (backup_prefix != new_prefix and len(backup_prefix) > 0):
-                for path, placeholder, mode in _prefix_records:
-                    update_prefix(os.path.join(new_prefix, path), new_prefix, backup_prefix, mode=mode)
-            elif  (backup_prefix != new_prefix and len(backup_prefix) == 0):
-                for path, placeholder, mode in _prefix_records:
-                    update_prefix(os.path.join(new_prefix, path), new_prefix, placeholder, mode=mode)
+            if (backup_prefix != new_prefix):
+                print('backup path: ' + backup_prefix +'differs with current path: ' + new_prefix + ' --- patching files...')
+                if (len(backup_prefix) > 0):
+                    for path, placeholder, mode in _prefix_records:
+                        update_prefix(os.path.join(new_prefix, path), new_prefix, backup_prefix, mode=mode)
+                elif (len(backup_prefix) == 0):
+                    for path, placeholder, mode in _prefix_records:
+                        update_prefix(os.path.join(new_prefix, path), new_prefix, placeholder, mode=mode)
         with open(patch_path_file, 'w') as fh:
             fh.write(new_prefix)
 """

--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -873,7 +873,12 @@ if __name__ == '__main__':
     args = parser.parse_args()
     # Manually handle version printing to output to stdout in python < 3.4
     if args.version:
-        print('conda-unpack {version}')
+        print('conda-unpack 0.4.0')
+    elif args.repack:
+        script_dir = os.path.dirname(__file__)
+        new_prefix = os.path.abspath(os.path.dirname(script_dir))
+        for path, placeholder, mode in _prefix_records:
+            update_prefix(os.path.join(new_prefix, path), placeholder, new_prefix, mode=mode, is_repacking=True)  
     else:
         script_dir = os.path.dirname(__file__)
         new_prefix = os.path.abspath(os.path.dirname(script_dir))

--- a/conda_pack/prefixes.py
+++ b/conda_pack/prefixes.py
@@ -83,8 +83,7 @@ def replace_prefix(data, mode, placeholder, new_prefix, is_repacking=False):
                                new_prefix.encode('utf-8'),
                                is_repacking)
         if (is_repacking):
-            print("length changed from {:d} to {:d} (diff {:d}). Removing padding...".format(len(data),
-                                len(data2), len(data2) - len(data)))
+            ## print("length changed from {:d} to {:d} (diff {:d}). Removing padding...".format(len(data), len(data2), len(data2) - len(data)))
             data3 = binary_remove_padding(data2, placeholder.encode('utf-8'), new_prefix.encode('utf-8'))
             data2 = data3
         if len(data2) != len(data):
@@ -125,7 +124,7 @@ else:
         
         neg_padding = (len(new_prefix) - len(placeholder)) - 1
         neg_padding_str = neg_padding.__str__().encode('utf-8')
-        pat = re.compile(re.escape(new_prefix[:150]) + b'([^\0]*?)(\0+)') # {' + neg_padding_str + b',} # note : regex can't take more than 192 characters. FUCK YOU PYTHON.
+        pat = re.compile(re.escape(new_prefix[:150]) + b'([^\0]*?)(\0+)') # note : regex can't take more than 192 characters, so I truncate the prefix to first 150.
         return pat.sub(replace, data)
 
     def binary_replace(data, placeholder, new_prefix, is_repacking=False):

--- a/conda_pack/prefixes.py
+++ b/conda_pack/prefixes.py
@@ -81,8 +81,7 @@ def replace_prefix(data, mode, placeholder, new_prefix):
         data2 = binary_replace(data,
                                placeholder.encode('utf-8'),
                                new_prefix.encode('utf-8'))
-        print("length changed from {:d} to {:d} (diff {:d}).".format(len(data),
-                                len(data2), len(data2) - len(data)))
+        ## print("length changed from {:d} to {:d} (diff {:d}).".format(len(data), len(data2), len(data2) - len(data)))
 
         if len(data2) != len(data):
             message = ("Found mismatched data length in binary file:\n"
@@ -116,7 +115,7 @@ else:
             padding = (len(new_prefix) - len(placeholder)) * occurences
             if padding < 0:
                 raise ValueError("negative padding while repacking")
-            print("\tfound " + occurences.__str__() + " occurences, hence padding = " + padding.__str__())
+            ## print("\tfound " + occurences.__str__() + " occurences, hence padding = " + padding.__str__())
             return match.group()[:-padding]
         
         pat = re.compile(re.escape(new_prefix[:150]) + b'([^\0]*?)(\0+)') # note : regex can't take more than 192 characters.


### PR DESCRIPTION
Fix #106 

This feature lets the user move their environment around while still fixing prefixes.

This works by logging in a text file called `current_path_patch.bak` the path where the conda environment has been previously unpacked with `conda-unpack`. After moving the folder to a now location, running `conda-unpack` again will read the previous path in the text file and replace it in all files.
With text file, it's easy. With binary files, it doesn't cause any offsets problem thanks to the fact that there's always a lot of padding in the binary file (since that's how conda works, by setting the path in binary files with a lot of padding to be sure that relatively long paths can be replaced). Since we read the previous path in the text file, we know its length, so we can replace it.

(Originally I added an option `--repack` that updates the paths with the current directory when run but you can just run it directly with `conda-unpack`. If there's no `current_path_patch.bak` it will behave just like before.)

You can test it with the compiled version at https://anaconda.org/jolevy/conda-pack/