### PR TITLE
Build a full conda tree for the testbed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,13 +55,22 @@ jobs:
           echo "::set-output name=value::$(dirname $GITHUB_WORKSPACE)/conda"
           echo "::set-env name=CONDA_ROOT::$CONDA_ROOT"
           echo "CONDA_ROOT: $CONDA_ROOT"
-    - id: cache
-      name: Retrieve or create the testbed cache
+    # Use a smaller cache entry to enable a quicker exit if we
+    # have already built the testbed. Any small file will do
+    - id: cache-key
+      name: Retrieve cache key
+      uses: actions/cache@v2
+      with:
+        path: LICENSE.txt
+        key: key-${{ matrix.os }}-${{ hashFiles('testing') }}-5
+    - name: Retrieve or create the testbed cache
+      if: steps.cache-key.outputs.cache-hit != 'true'
       uses: actions/cache@v2
       with:
         path: ${{ steps.conda-root.outputs.value }}
         key: testbed-${{ matrix.os }}-${{ hashFiles('testing') }}-5
     - name: Verify or create the testbed
+      if: steps.cache-key.outputs.cache-hit != 'true'
       run: testing/setup_envs.sh
   tests:
     defaults:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,18 +61,8 @@ jobs:
       with:
         path: ${{ steps.conda-root.outputs.value }}
         key: testbed-${{ matrix.os }}-${{ hashFiles('testing') }}-5
-    - name: Create the testbed
-      if: steps.cache.outputs.cache-hit != 'true'
-      # We use the built-in conda to create our own independent conda
-      # root. So we can fully control the contents of its package cache
-      run: |
-        [ "$RUNNER_OS" == "Windows" ] && CONDA_EXE="$CONDA/Scripts/conda.exe"
-        [ "$RUNNER_OS" == "macOS" ] && export CONDA_PKGS_DIRS=~/.pkgs
-        bash testing/setup_envs.sh
-    - name: conda info -a
-      run: |
-        source $CONDA_ROOT/etc/profile.d/conda.sh
-        conda info -a
+    - name: Verify or create the testbed
+      run: testing/setup_envs.sh
   tests:
     defaults:
       run:
@@ -104,6 +94,8 @@ jobs:
       with:
         name: package-${{ github.sha }}
         path: conda-bld
+    - name: Verify or create the testbed
+      run: testing/setup_envs.sh
     - name: Create the test environment and run the tests
       run: |
         source $CONDA_ROOT/etc/profile.d/conda.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,17 +66,8 @@ jobs:
       # We use the built-in conda to create our own independent conda
       # root. So we can fully control the contents of its package cache
       run: |
-        [ "$RUNNER_OS" == "Windows" ] && CONDA_E="$CONDA/Scripts/conda.exe"
+        [ "$RUNNER_OS" == "Windows" ] && CONDA_EXE="$CONDA/Scripts/conda.exe"
         [ "$RUNNER_OS" == "macOS" ] && export CONDA_PKGS_DIRS=~/.pkgs
-        # We need to move the package cache to a writable location on the Mac
-        # to work around an issue with GitHub's implementation. But we also
-        # need to make sure to remove the workaround once our conda is in, so
-        # that the cache is in $CONDA_PREFIX/pkgs where we expect it.
-        ${CONDA_E:-conda} create -p $CONDA_ROOT conda
-        unset CONDA_PKGS_DIRS
-        source $CONDA_ROOT/etc/profile.d/conda.sh
-        conda activate base
-        export CONDA_PACK_TEST_ENVS=$CONDA_ROOT/envs
         bash testing/setup_envs.sh
     - name: conda info -a
       run: |
@@ -120,5 +111,4 @@ jobs:
         mv conda-bld $CONDA_ROOT/conda-bld
         conda create -n cptest local::conda-pack pytest python=${{ matrix.pyver }}
         conda activate cptest
-        export CONDA_PACK_TEST_ENVS=$CONDA_ROOT/envs
         pytest -v -ss conda_pack/tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-testing/environments/*
+testing/conda/*
 build
 dist
 conda_pack.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 testing/conda/*
 build
 dist
-conda_pack.egg-info
+*.egg-info
+.gitignore.swp
 .cache
 .coverage
 htmlcov/

--- a/conda_pack/tests/conftest.py
+++ b/conda_pack/tests/conftest.py
@@ -9,10 +9,10 @@ import pytest
 
 
 test_dir = os.path.dirname(os.path.abspath(__file__))
-env_dir = os.environ.get('CONDA_PACK_TEST_ENVS')
-if env_dir is None:
-    env_dir = os.path.join(test_dir, '..', '..', 'testing', 'environments')
-env_dir = os.path.abspath(env_dir)
+croot = os.environ.get('CONDA_ROOT')
+if croot is None:
+    croot = os.path.join(test_dir, '..', '..', 'testing', 'conda')
+env_dir = os.path.join(os.path.abspath(croot), 'envs')
 
 py27_path = os.path.join(env_dir, 'py27')
 py36_path = os.path.join(env_dir, 'py36')

--- a/conda_pack/tests/conftest.py
+++ b/conda_pack/tests/conftest.py
@@ -1,12 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
-import json
-import glob
 import os
-import shutil
-
-import pytest
-
 
 test_dir = os.path.dirname(os.path.abspath(__file__))
 croot = os.environ.get('CONDA_ROOT')
@@ -22,20 +16,3 @@ py36_missing_files_path = os.path.join(env_dir, 'py36_missing_files')
 nopython_path = os.path.join(env_dir, 'nopython')
 has_conda_path = os.path.join(env_dir, 'has_conda')
 activate_scripts_path = os.path.join(env_dir, 'activate_scripts')
-
-
-@pytest.fixture
-def broken_package_cache():
-    metas = glob.glob(os.path.join(py27_path, 'conda-meta',
-                                   'conda_pack_test_lib2*.json'))
-
-    if len(metas) != 1:
-        raise ValueError("%d metadata files found for conda_pack_test_lib2, "
-                         "expected only 1" % len(metas))
-
-    with open(os.path.join(metas[0])) as fil:
-        info = json.load(fil)
-    pkg = info['link']['source']
-
-    if os.path.exists(pkg):
-        shutil.rmtree(pkg)

--- a/conda_pack/tests/test_cli.py
+++ b/conda_pack/tests/test_cli.py
@@ -117,7 +117,7 @@ def test_cli_exceptions(capsys):
 
 
 @pytest.mark.xfail(on_p2, reason='Relaxing python 2 tests on CI')
-def test_cli_warnings(capsys, broken_package_cache, tmpdir):
+def test_cli_warnings(capsys, tmpdir):
     out_path = os.path.join(str(tmpdir), 'py27.tar')
 
     with pytest.raises(SystemExit) as exc:

--- a/conda_pack/tests/test_core.py
+++ b/conda_pack/tests/test_core.py
@@ -73,7 +73,7 @@ def test_from_prefix():
 
 
 @pytest.mark.xfail(sys.version[0] == '2', reason="Python 2 failure")
-def test_missing_package_cache(broken_package_cache):
+def test_missing_package_cache():
     with pytest.warns(UserWarning) as record:
         env = CondaEnv.from_prefix(py27_path)
 

--- a/testing/setup_envs.sh
+++ b/testing/setup_envs.sh
@@ -6,12 +6,30 @@ echo Setting up environments for testing
 
 cwd=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)
 ymls=$cwd/env_yamls
-if [[ "$CONDA_PACK_TEST_ENVS" != "" ]]; then
-    mkdir -p $CONDA_PACK_TEST_ENVS
-    envs=$(cd $CONDA_PACK_TEST_ENVS && pwd)
+if [[ "$CONDA_ROOT" != "" ]]; then
+    mkdir -p $CONDA_ROOT
+    croot=$(cd $CONDA_ROOT && pwd)
 else
-    envs=$cwd/environments
+    croot=$cwd/conda
 fi
+envs=$croot/envs
+
+if [ ! -d $croot/conda-meta ]; then
+    ${CONDA_EXE:-conda} create -y -p $croot conda python=3.7
+fi
+
+source $croot/etc/profile.d/conda.sh
+export CONDA_PKGS_DIRS=$croot/pkgs
+
+if [ -d $croot/envs/activate_scripts/conda-meta ]; then
+    conda info
+    ls -l $croot/envs
+    exit 0
+fi
+
+mkdir -p $envs
+# Make sure the local package cache is used
+rm -rf $croot/pkgs
 
 echo Creating py27 environment
 env=$envs/py27
@@ -77,3 +95,7 @@ else
     cp $cwd/extra_scripts/conda_pack_test_activate.sh $env/etc/conda/activate.d
     cp $cwd/extra_scripts/conda_pack_test_deactivate.sh $env/etc/conda/deactivate.d
 fi
+
+rm -f $croot/pkgs/{*.tar.bz2,*.conda}
+conda info
+ls -l $croot/envs

--- a/testing/setup_envs.sh
+++ b/testing/setup_envs.sh
@@ -4,6 +4,10 @@ set -Eeo pipefail
 
 echo Setting up environments for testing
 
+# GitHub action specific items. These are no-ops locally
+[ "$RUNNER_OS" == "Windows" ] && CONDA_EXE="$CONDA/Scripts/conda.exe"
+[ "$RUNNER_OS" == "macOS" ] && export CONDA_PKGS_DIRS=~/.pkgs
+
 cwd=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)
 ymls=$cwd/env_yamls
 if [[ "$CONDA_ROOT" != "" ]]; then

--- a/testing/setup_envs.sh
+++ b/testing/setup_envs.sh
@@ -34,6 +34,8 @@ rm -rf $croot/pkgs
 echo Creating py27 environment
 env=$envs/py27
 conda env create -f $ymls/py27.yml -p $env
+# Remove this package from the cache for testing
+rm -rf $croot/pkgs/conda_pack_test_lib2*py27*
 
 echo Creating py36 environment
 env=$envs/py36


### PR DESCRIPTION
This creates a full conda environment in which to host the testing environments, including the package cache itself. This gives us full control over the package cache for testing, so we can enable new tests that manipulate the package cache without disrupting developer's local work.