### PR TITLE
Add parcel support

### DIFF
--- a/conda_pack/cli.py
+++ b/conda_pack/cli.py
@@ -28,7 +28,8 @@ def build_parser():
     if sys.version_info >= (3, 5):
         kwargs['allow_abbrev'] = False
     parser = argparse.ArgumentParser(**kwargs)
-    parser.add_argument("--name", "-n", metavar="ENV",
+    parser.add_argument("--name", "-n",
+                        metavar="ENV",
                         help="The name of the environment to pack. "
                         "If neither --name nor --prefix are supplied, "
                         "the current activated environment is packed.")

--- a/conda_pack/cli.py
+++ b/conda_pack/cli.py
@@ -55,17 +55,18 @@ def build_parser():
                               "--parcel-root, --parcel-name, and "
                               "--parcel-version options."))
     parser.add_argument("--parcel-root", default=None,
-                        help="The location where all parcels are unpacked on the "
-                        "target Hadoop cluster (default: '/opt/cloudera/parcels'). "
-                        "Ignored if the format is not a parcel.")
+                        help="(Parcels only) The location where all parcels are unpacked "
+                        "on the target Hadoop cluster (default: '/opt/cloudera/parcels').")
     parser.add_argument("--parcel-name", default=None,
-                        help="The name of the parcel, without a version suffix. "
-                        "The default value is the local environment name.")
+                        help="(Parcels only) The name of the parcel, without a version "
+                        "suffix. The default value is the local environment name. The parcel "
+                        "name may not have any hyphens.")
     parser.add_argument("--parcel-version", default=None,
-                        help="The version number for the parcel. The default value "
-                        "is the current date, using the format YYYY.MM.DD.")
+                        help="(Parcels only) The version number for the parcel. The default "
+                        "value is the current date, using the format YYYY.MM.DD.")
     parser.add_argument("--parcel-distro", default=None,
-                        help="The distribution for the parcel. The default value is 'el7'.")
+                        help="(Parcels only) The distribution type for the parcel. The "
+                        "default value is 'el7'. This value cannot have any hyphens.")
     parser.add_argument("--format",
                         choices=['infer', 'zip', 'tar.gz', 'tgz', 'tar.bz2',
                                  'tbz2', 'tar', 'parcel'],

--- a/conda_pack/cli.py
+++ b/conda_pack/cli.py
@@ -28,13 +28,14 @@ def build_parser():
     if sys.version_info >= (3, 5):
         kwargs['allow_abbrev'] = False
     parser = argparse.ArgumentParser(**kwargs)
-    parser.add_argument("--name", "-n",
-                        metavar="ENV",
-                        help=("Name of existing environment. Default is "
-                              "current environment."))
+    parser.add_argument("--name", "-n", metavar="ENV",
+                        help="The name of the environment to pack. "
+                        "If neither --name nor --prefix are supplied, "
+                        "the current activated environment is packed.")
     parser.add_argument("--prefix", "-p",
                         metavar="PATH",
-                        help="Full path to environment prefix.")
+                        help="The path to the environment to pack. "
+                        "Only one of --name/--prefix should be supplied.")
     parser.add_argument("--output", "-o",
                         metavar="PATH",
                         help=("The path of the output file. Defaults to the "
@@ -48,10 +49,24 @@ def build_parser():
                         metavar="PATH",
                         help=("If present, prefixes will be rewritten to this "
                               "path before packaging. In this case the "
-                              "`conda-unpack` script will not be generated."))
+                              "`conda-unpack` script will not be generated. "
+                              "This option should not be used with parcels, which "
+                              "instead generate their destination prefix from the "
+                              "--parcel-root, --parcel-name, and "
+                              "--parcel-version options."))
+    parser.add_argument("--parcel-root", default=None,
+                        help="The location where all parcels are unpacked on the "
+                        "target Hadoop cluster (default: '/opt/cloudera/parcels'). "
+                        "Ignored if the format is not a parcel.")
+    parser.add_argument("--parcel-name", default=None,
+                        help="The name of the parcel, without a version suffix. "
+                        "The default value is the local environment name.")
+    parser.add_argument("--parcel-version", default=None,
+                        help="The version number for the parcel. The default value "
+                        "is the current date, using the format YYYY.MM.DD.")
     parser.add_argument("--format",
                         choices=['infer', 'zip', 'tar.gz', 'tgz', 'tar.bz2',
-                                 'tbz2', 'tar'],
+                                 'tbz2', 'tar', 'parcel'],
                         default='infer',
                         help=("The archival format to use. By default this is "
                               "inferred by the output file extension."))
@@ -120,8 +135,12 @@ def build_parser():
 PARSER = build_parser()
 
 
-def fail(msg):
+def warn(msg):
     print(msg, file=sys.stderr)
+
+
+def fail(msg):
+    warn(msg)
     sys.exit(1)
 
 
@@ -146,6 +165,9 @@ def main(args=None, pack=pack):
                  zip_64=not args.no_zip_64,
                  arcroot=args.arcroot,
                  dest_prefix=args.dest_prefix,
+                 parcel_root=args.parcel_root,
+                 parcel_name=args.parcel_name,
+                 parcel_version=args.parcel_version,
                  verbose=not args.quiet,
                  filters=args.filters,
                  ignore_editable_packages=args.ignore_editable_packages,

--- a/conda_pack/cli.py
+++ b/conda_pack/cli.py
@@ -64,6 +64,8 @@ def build_parser():
     parser.add_argument("--parcel-version", default=None,
                         help="The version number for the parcel. The default value "
                         "is the current date, using the format YYYY.MM.DD.")
+    parser.add_argument("--parcel-distro", default=None,
+                        help="The distribution for the parcel. The default value is 'el7'.")
     parser.add_argument("--format",
                         choices=['infer', 'zip', 'tar.gz', 'tgz', 'tar.bz2',
                                  'tbz2', 'tar', 'parcel'],
@@ -135,12 +137,8 @@ def build_parser():
 PARSER = build_parser()
 
 
-def warn(msg):
-    print(msg, file=sys.stderr)
-
-
 def fail(msg):
-    warn(msg)
+    print(msg, file=sys.stderr)
     sys.exit(1)
 
 
@@ -168,6 +166,7 @@ def main(args=None, pack=pack):
                  parcel_root=args.parcel_root,
                  parcel_name=args.parcel_name,
                  parcel_version=args.parcel_version,
+                 parcel_distro=args.parcel_distro,
                  verbose=not args.quiet,
                  filters=args.filters,
                  ignore_editable_packages=args.ignore_editable_packages,

--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -404,7 +404,8 @@ def pack(name=None, prefix=None, output=None, format='infer',
     output : str, optional
         The path of the output file. Defaults to the environment name with a
         ``.tar.gz`` suffix (e.g. ``my_env.tar.gz``).
-    format : {'infer', 'zip', 'tar.gz', 'tgz', 'tar.bz2', 'tbz2', 'tar', 'parcel'}, optional
+    format : {'infer', 'zip', 'tar.gz', 'tgz', 'tar.bz2',
+              'tbz2', 'tar', 'parcel'}, optional
         The archival format to use. By default this is inferred by the output
         file extension.
     arcroot : str, optional
@@ -901,7 +902,7 @@ _parcel_json_template = """\
   "extraVersionInfo": {{
     "baseVersion": "{parcel_version}",
     "fullVersion": "{parcel_version}",
-    "patchCount": "p0",
+    "patchCount": "p0"
   }},
   "groups": [],
   "name": "{parcel_name}",

--- a/conda_pack/formats.py
+++ b/conda_pack/formats.py
@@ -38,7 +38,7 @@ def archive(fileobj, arcroot, format, compress_level=4, zip_symlinks=False,
                           zip_64=zip_64)
 
     # Tar archives
-    if format in ('tar.gz', 'tgz'):
+    if format in ('tar.gz', 'tgz', 'parcel'):
         if n_threads == 1:
             mode = 'w:gz'
             close_file = False

--- a/conda_pack/scripts/posix/parcel
+++ b/conda_pack/scripts/posix/parcel
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+local CDH_PREFIX="${PARCELS_ROOT}/${PARCEL_DIRNAME}"
+
+if [ -z "${CDH_PYTHON}" ]; then
+    export CDH_PYTHON=${CDH_PREFIX}/bin/python
+fi
+
+# Run the activate scripts
+local _script_dir="${CDH_PREFIX}/etc/conda/activate.d"
+if [ -d "$_script_dir" ] && [ -n "$(ls -A "$_script_dir")" ]; then
+    local _path
+    for _path in "$_script_dir"/*.sh; do
+        . "$_path"
+    done
+fi

--- a/conda_pack/tests/test_core.py
+++ b/conda_pack/tests/test_core.py
@@ -213,7 +213,7 @@ def test_output_and_format(py36_env):
     assert output == 'py36.tar.gz'
     assert format == 'tar.gz'
 
-    for format in ['tar.gz', 'tar.bz2', 'tar', 'zip']:
+    for format in ['tar.gz', 'tar.bz2', 'tar', 'zip', 'parcel']:
         output = os.extsep.join([py36_env.name, format])
 
         o, f = py36_env._output_and_format(format=format)
@@ -233,6 +233,9 @@ def test_output_and_format(py36_env):
 
     with pytest.raises(CondaPackException):
         py36_env._output_and_format(output='foo.bar')
+
+    with pytest.raises(CondaPackException):
+        py36_env._output_and_format(output='foo.parcel', format='zip')
 
 
 def test_roundtrip(tmpdir, py36_env):
@@ -476,6 +479,37 @@ def test_pack(tmpdir, py36_env):
     assert diff == set(os.path.join(BIN_DIR_L, f) for f in fnames)
 
 
+def _test_dest_prefix(src_prefix, dest_prefix, arcroot, out_path, format):
+    if on_win:
+        test_files = ['Scripts/conda-pack-test-lib1',
+                      'Scripts/pytest.exe']
+    else:
+        test_files = ['bin/conda-pack-test-lib1',
+                      'bin/pytest',
+                      'bin/clear']
+
+    orig_bytes = src_prefix.encode()
+    orig_bytes_l = src_prefix.lower().encode() if on_win else orig_bytes
+    new_bytes = dest_prefix.encode()
+    new_bytes_l = dest_prefix.lower().encode() if on_win else new_bytes
+
+    # all paths, including shebangs, are rewritten using the prefix
+    with tarfile.open(out_path) as fil:
+        for path in fil.getnames():
+            assert os.path.basename(path) != 'conda-unpack', path
+            if arcroot:
+                assert path.startswith(arcroot), path
+        for test_file in test_files:
+            orig_path = os.path.join(src_prefix, test_file)
+            dest_path = os.path.join(arcroot, test_file)
+            with open(orig_path, 'rb') as fil2:
+                orig_data = fil2.read()
+            if orig_bytes in orig_data:
+                data = fil.extractfile(dest_path).read()
+                assert orig_bytes not in data and orig_bytes_l not in data, test_file
+                assert new_bytes in data or new_bytes_l in data, test_file
+
+
 def test_dest_prefix(tmpdir, py36_env):
     out_path = os.path.join(str(tmpdir), 'py36.tar')
     dest = r'c:\foo\bar\baz\biz' if on_win else '/foo/bar/baz/biz'
@@ -487,35 +521,45 @@ def test_dest_prefix(tmpdir, py36_env):
     assert os.path.exists(out_path)
     assert tarfile.is_tarfile(out_path)
 
-    with tarfile.open(out_path) as fil:
-        paths = fil.getnames()
+    _test_dest_prefix(py36_env.prefix, dest, '', out_path, 'r')
 
-    # No conda-unpack generated
-    assert 'conda-unpack' not in paths
 
+def test_parcel(tmpdir, py36_env):
     if on_win:
-        test_files = ['Scripts/conda-pack-test-lib1',
-                      'Scripts/pytest.exe']
-    else:
-        test_files = ['bin/conda-pack-test-lib1',
-                      'bin/pytest',
-                      'bin/clear']
+        pytest.skip("Not parcel tests on Windows")
+    arcroot = 'py36-1234.56'
 
-    orig_bytes = py36_env.prefix.encode()
-    orig_bytes_l = py36_env.prefix.lower().encode() if on_win else orig_bytes
-    new_bytes = dest.encode()
-    new_bytes_l = dest.lower().encode() if on_win else new_bytes
+    out_path = os.path.join(str(tmpdir), arcroot + '.parcel')
 
-    # all paths, including shebangs, are rewritten using the prefix
+    pdir = os.getcwd()
+    try:
+        os.chdir(str(tmpdir))
+        res = pack(prefix=py36_path, format='parcel', parcel_version='1234.56')
+    finally:
+        os.chdir(pdir)
+
+    assert os.path.join(str(tmpdir), res) == out_path
+    assert os.path.exists(out_path)
+
+    # Verify that only the parcel files were added
+    with tarfile.open(out_path, 'r:gz') as fil:
+        paths = fil.getnames()
+    sol = set(os.path.join(arcroot, f.target) for f in py36_env.files)
+    diff = set(paths).difference(sol)
+    fnames = ('conda_env.sh', 'parcel.json')
+    assert diff == set(os.path.join(arcroot, 'meta', f) for f in fnames)
+
+    # Verify correct metadata in parcel.json
     with tarfile.open(out_path) as fil:
-        for test_file in test_files:
-            orig_path = os.path.join(py36_env.prefix, test_file)
-            with open(orig_path, 'rb') as fil2:
-                orig_data = fil2.read()
-            if orig_bytes in orig_data:
-                data = fil.extractfile(test_file).read()
-                assert orig_bytes not in data and orig_bytes_l not in data, test_file
-                assert new_bytes in data or new_bytes_l in data, test_file
+        fpath = os.path.join(arcroot, 'meta', 'parcel.json')
+        data = fil.extractfile(fpath).read()
+    data = json.loads(data)
+    assert data['name'] == 'py36' and data['components'][0]['name'] == 'py36'
+    assert data['version'] == '1234.56' and data['components'][0]['version'] == '1234.56'
+
+    # Verify the correct dest_prefix substitution
+    dest = os.path.join('/opt/cloudera/parcels', arcroot)
+    _test_dest_prefix(py36_env.prefix, dest, arcroot, out_path, 'r:gz')
 
 
 def test_activate(tmpdir):

--- a/conda_pack/tests/test_core.py
+++ b/conda_pack/tests/test_core.py
@@ -529,7 +529,7 @@ def test_parcel(tmpdir, py36_env):
         pytest.skip("Not parcel tests on Windows")
     arcroot = 'py36-1234.56'
 
-    out_path = os.path.join(str(tmpdir), arcroot + '.parcel')
+    out_path = os.path.join(str(tmpdir), arcroot + '-el7.parcel')
 
     pdir = os.getcwd()
     try:

--- a/conda_pack/tests/test_core.py
+++ b/conda_pack/tests/test_core.py
@@ -218,7 +218,7 @@ def test_output_and_format(py36_env):
 
         o, f = py36_env._output_and_format(format=format)
         assert f == format
-        assert o == output
+        assert o == (None if f == 'parcel' else output)
 
         o, f = py36_env._output_and_format(output=output)
         assert o == output

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -171,6 +171,6 @@ This tool has a few caveats.
 .. toctree::
     :hidden:
 
-    api.rst
     cli.rst
+    api.rst
     spark.rst

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,11 +24,13 @@ Use Cases
 
 - Bundling an application with its environment for deployment
 
-- Packaging a conda environment for usage with Apache Spark when deploying on
+- Packaging a conda environment for use with Apache Spark when deploying on
   YARN (:doc:`see here <spark>` for more information).
 
 - Packaging a conda environment for deployment on Apache YARN. One way to do
   this is to use `Skein <https://jcrist.github.io/skein/>`_.
+
+- Packaging a conda environment as a standard Cloudera parcel.
 
 - Archiving an environment in a functioning state. Note that a more sustainable
   way to do this is to specify your environment as a `environment.yml

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,13 +30,16 @@ Use Cases
 - Packaging a conda environment for deployment on Apache YARN. One way to do
   this is to use `Skein <https://jcrist.github.io/skein/>`_.
 
-- Packaging a conda environment as a standard Cloudera parcel.
-
 - Archiving an environment in a functioning state. Note that a more sustainable
   way to do this is to specify your environment as a `environment.yml
   <https://conda.io/docs/user-guide/tasks/manage-environments.html#sharing-an-environment>`_,
   and recreate the environment when needed.
 
+- *BETA*: Packaging a conda environment as a standard Cloudera parcel. This is
+  a newly added capability. It has been tested on a live cluster, but different
+  cluster configurations may produce different results. We welcome users to
+  `file an issue <https://github.com/conda/conda-pack/issues>`_ if necessary.
+  :doc:`See here <parcel>` for more information).
 
 Installation
 ------------
@@ -174,3 +177,5 @@ This tool has a few caveats.
     cli.rst
     api.rst
     spark.rst
+    parcel.rst
+

--- a/docs/source/parcel.rst
+++ b/docs/source/parcel.rst
@@ -1,0 +1,76 @@
+Parcels
+=======
+
+Conda-pack has recently been enhanced with the ability to generate
+`parcels <https://docs.cloudera.com/documentation/enterprise/latest/topics/cm_ig_parcels.html>`_
+for use on Cloudera Hadoop clusters. The file formats for parcels and
+conda-packs are nearly identical. In fact, it was possible even with
+older versions of conda-pack to build parcels as follows:
+
+1. Add two unmanaged files to the environment:
+
+   - ``meta/parcel.json``:, a file of parcel-specific metadata
+   - ``meta/conda_env.sh``: a simple activation script. The filename
+     is flexible, and is recorded in the metadata file.
+
+2. Pack the environment with specifically chosen values of
+   ``--arcroot``, ``--dest-prefix``, and ``--output``.
+
+The latest version of conda-pack has been enhanced to eliminate the manual
+aspects of this work. The key is the introduction of a ``--format parcel``
+option and four parcel-specific options:
+
+- ``--parcel-name``: the base name of the parcel
+
+  By default, this value will be taken from the basename of the selected environment
+  directory. Parcel names may not have dashes ``-``, however, so if the name of the
+  environment contains a dash, use this option to provide a compliant alternative.
+- ``--parcel-version``: the version of the parcel
+
+  This is generally expected to follow a standard `semver <https://semver.org/>`_
+  format. If not supplied, conda-pack will autogenerate one from today's date in
+  ``YYYY.MM.DD`` format.
+- ``--parcel-distribution``: the target distribution for the parcel. 
+
+  This is an abbreviation describing the specific operating system on which
+  your Cloudera clsuter runs. Its default value is ``el7``, corresponding
+  to RHEL7/CentOS7. Other common values include ``el6``, ``sles12``, ``bionic``,
+  and ``xenial``.
+
+- ``--parcel-root``: the location where parcels are unpacked on the cluster
+
+  The default value of this location is ``/opt/cloudera/parcels``. Unless your
+  cluster manager has modified this default, there should be no need to change
+  this, but it is essential that this matches your configuration.
+
+In many cases, it will not be necessary to override any of these options,
+because conda-pack provides sensible defaults. Given these values, conda-pack
+generates values for the following internal options:
+
+- ``arcroot``: ``{parcel_name}-{parcel_version}``
+- ``dest_prefix``: ``{parcel_root}/{parcel_name}-{parcel_version}``
+- ``output`` (filename): ``{parcel_name}-{parcel_version}-{parcel_distro}.parcel``
+
+Conda-pack will exit with an error if you attempt to override the ``dest-prefix``
+or ``arcroot`` options. We recommend against overriding the ``output`` option,
+but conda-pack does not prevent this.
+
+Example
+-------
+
+Create an environment:
+
+.. code-block:: bash
+
+    $ conda create -y -n example python=3.5 numpy pandas scikit-learn
+
+
+Package the environment into a parcel:
+
+.. code-block:: bash
+
+    $ conda pack -n example --format parcel --parcel-name=sklearn
+    Collecting packages...
+    Packing environment at '/Users/mgrant/miniconda3/envs/example' to 'sklearn-2020.09.15-el7.parcel'
+    [########################################] | 100% Completed |  9.8s
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 exclude = __init__.py
-max-line-length = 90
+max-line-length = 99
 
 [versioneer]
 VCS = git

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 exclude = __init__.py
-max-line-length = 99
+max-line-length = 100 
 
 [versioneer]
 VCS = git


### PR DESCRIPTION
Parcels and conda-packs are in spitting distance of each other:

- Parcels include the base name of the directory in the archive, whereas conda-pack archives, by default, do not—but can do so optionally with the `--arcroot` option.
- Parcels are given a `.parcel` suffix but in fact are in the `.tar.gz` format
- Parcels have some additional metadata in the `meta/` subdirectory:
  - A `parcel.json` file providing important information about the parcel;
  - An activation script. The name is provided in `parcel.json`, and we have called it `conda_env.sh`.
- Parcels are immutable, which from a `conda-pack` perspective means they need the `--dest-prefix` supplied, and it must match where the parcel is unpacked.

This code bridges this gap and in doing so allows conda-pack to build parcels.