### PR TITLE
Handle malformed conda packages with info/ files in paths.json

### DIFF
--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -649,7 +649,7 @@ def read_has_prefix(path):
 def load_files(prefix):
     from os.path import relpath, join, isfile, islink
 
-    ignore = {'pkgs', 'envs', 'conda-bld', '.conda_lock', 'users', 'info',
+    ignore = {'pkgs', 'envs', 'conda-bld', '.conda_lock', 'users',
               'conda-recipes', '.index', '.unionfs', '.nonadmin', 'python.app',
               'Launcher.app'}
 

--- a/testing/env_yamls/has_conda.yml
+++ b/testing/env_yamls/has_conda.yml
@@ -3,4 +3,3 @@ name: has_conda
 dependencies:
     - conda
     - toolz
-    - python=3.7


### PR DESCRIPTION
Fixes #145, which is caused by a small handful of malformed conda packages. Most conda packages do not create files in the `info/` subdirectory of a conda environment. The current version of `conda-pack` ignores this directory when packing. But a few malformed conda packages do install files into this directory. So by ignoring this directory, conda-pack spits out missing file errors.