### PR TITLE
Improve the missing file messaging with a partial listing of the missing files

### DIFF
--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -849,10 +849,9 @@ def load_environment(prefix, on_missing_cache='warn', ignore_editable_packages=F
         for key, value in missing_files.items():
             packages.append('- %s %s:' % key)
             value = sorted(value)
-            if len(value) > 3:
+            if len(value) > 4:
                 value = value[:3] + ['+ %d others' % (len(value) - 3)]
-            for p in value:
-                packages.append('    %s' % p)
+            packages.extend('    ' + p for p in value)
         packages = '\n'.join(packages)
         raise CondaPackException(_missing_files_error.format(packages))
 

--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -799,7 +799,7 @@ def load_environment(prefix, on_missing_cache='warn', ignore_editable_packages=F
     files = []
     managed = set()
     uncached = []
-    missing_files = []
+    missing_files = {}
     for path in os.listdir(conda_meta):
         if path.endswith('.json'):
             with open(os.path.join(conda_meta, path)) as fil:
@@ -819,11 +819,12 @@ def load_environment(prefix, on_missing_cache='warn', ignore_editable_packages=F
                                                  all_files)
 
             targets = {os.path.normcase(f.target) for f in new_files}
+            new_missing = targets.difference(all_files)
 
-            if targets.difference(all_files):
+            if new_missing:
                 # Collect packages missing files as we progress to provide a
                 # complete error message on failure.
-                missing_files.append((info['name'], info['version']))
+                missing_files[(info['name'], info['version'])] = new_missing
 
             managed.update(targets)
             files.extend(new_files)
@@ -844,7 +845,15 @@ def load_environment(prefix, on_missing_cache='warn', ignore_editable_packages=F
                       file_mode=None))
 
     if missing_files and not ignore_missing_files:
-        packages = '\n'.join('- %s=%r' % i for i in missing_files)
+        packages = []
+        for key, value in missing_files.items():
+            packages.append('- %s %s:' % key)
+            value = sorted(value)
+            if len(value) > 3:
+                value = value[:3] + ['+ %d others' % (len(value) - 3)]
+            for p in value:
+                packages.append('    %s' % p)
+        packages = '\n'.join(packages)
         raise CondaPackException(_missing_files_error.format(packages))
 
     # Add unmanaged files, preserving their original case

--- a/conda_pack/tests/test_core.py
+++ b/conda_pack/tests/test_core.py
@@ -112,7 +112,8 @@ def test_missing_files():
         CondaEnv.from_prefix(py36_missing_files_path)
 
     msg = str(exc.value)
-    assert "toolz" in msg
+    assert "{}toolz{}__init__.py".format(os.sep, os.sep) in msg, msg
+    assert "{}toolz{}_signatures.py".format(os.sep, os.sep) in msg, msg
 
 
 def test_missing_files_ignored():

--- a/testing/setup_envs.sh
+++ b/testing/setup_envs.sh
@@ -77,9 +77,9 @@ echo Creating py36_missing_files environment
 env=$envs/py36_missing_files
 conda env create -f $ymls/py36.yml -p $env
 if [ -f $env/python.exe ]; then
-    rm $env/lib/site-packages/toolz/__init__.py
+    rm $env/lib/site-packages/toolz/*.py
 else
-    rm $env/lib/python3.6/site-packages/toolz/__init__.py
+    rm $env/lib/python3.6/site-packages/toolz/*.py
 fi
 
 echo Creating nopython environment


### PR DESCRIPTION
One of the challenges with the 'missing files' exception is that there is no information about what those missing files _are_. This adjustment to that exception message fixes that by providing a partial listing of the files that were discovered missing.

For example, the `py36_missing_files` environment in the testbed now has all of the `.py` files from the `toolz` package removed. The error message returned when packing that environment looks like this now:
```
Collecting packages...
CondaPackError: 
Files managed by conda were found to have been deleted/overwritten in the
following packages:

- toolz 0.10.0:
    lib/python3.6/site-packages/toolz/__init__.py
    lib/python3.6/site-packages/toolz/_signatures.py
    lib/python3.6/site-packages/toolz/compatibility.py
    + 5 others

This is usually due to `pip` uninstalling or clobbering conda managed files,
resulting in an inconsistent environment. Please check your environment for
conda/pip conflicts using `conda list`, and fix the environment by ensuring
only one version of each package is installed (conda preferred).
```