### PR TITLE
Replace local kw by typeset: will work in ksh and bash, fails in sh

### DIFF
--- a/conda_pack/scripts/posix/activate
+++ b/conda_pack/scripts/posix/activate
@@ -1,5 +1,5 @@
 _conda_pack_activate() {
-    local _CONDA_SHELL_FLAVOR
+    typeset _CONDA_SHELL_FLAVOR
     if [ -n "${BASH_VERSION:+x}" ]; then
         _CONDA_SHELL_FLAVOR=bash
     elif [ -n "${ZSH_VERSION:+x}" ]; then
@@ -10,7 +10,7 @@ _conda_pack_activate() {
         _CONDA_SHELL_FLAVOR=posh
     else
         # https://unix.stackexchange.com/a/120138/92065
-        local _q="$(ps -p$$ -o cmd="",comm="",fname="" 2>/dev/null | sed 's/^-//' | grep -oE '\w+' | head -n1)"
+        typeset _q="$(ps -p$$ -o cmd="",comm="",fname="" 2>/dev/null | sed 's/^-//' | grep -oE '\w+' | head -n1)"
         if [ "$_q" = dash ]; then
             _CONDA_SHELL_FLAVOR=dash
         else
@@ -20,7 +20,7 @@ _conda_pack_activate() {
     fi
 
     # https://unix.stackexchange.com/questions/4650/determining-path-to-sourced-shell-script/
-    local script_dir
+    typeset script_dir
     case "$_CONDA_SHELL_FLAVOR" in
         bash) script_dir="$(dirname "${BASH_SOURCE[0]}")";;
         zsh) script_dir="$(dirname "${(%):-%x}")";;  # http://stackoverflow.com/a/28336473/2127762
@@ -28,9 +28,9 @@ _conda_pack_activate() {
         *) script_dir="$(cd "$(dirname "$_")" && echo "$PWD")";;
     esac
 
-    local full_path_script_dir="$(cd "${script_dir}" && pwd)"
-    local full_path_env="$(dirname "$full_path_script_dir")"
-    local env_name="$(basename "$full_path_env")"
+    typeset full_path_script_dir="$(cd "${script_dir}" && pwd)"
+    typeset full_path_env="$(dirname "$full_path_script_dir")"
+    typeset env_name="$(basename "$full_path_env")"
 
     # If there's already a source env
     if [ -n "$CONDA_PREFIX" ]; then
@@ -57,9 +57,9 @@ _conda_pack_activate() {
     esac
 
     # Run the activate scripts
-    local _script_dir="${full_path_env}/etc/conda/activate.d"
+    typeset _script_dir="${full_path_env}/etc/conda/activate.d"
     if [ -d "$_script_dir" ] && [ -n "$(ls -A "$_script_dir")" ]; then
-        local _path
+        typeset _path
         for _path in "$_script_dir"/*.sh; do
             . "$_path"
         done

--- a/conda_pack/scripts/posix/deactivate
+++ b/conda_pack/scripts/posix/deactivate
@@ -2,19 +2,19 @@ _conda_pack_deactivate () {
     # If there's an active environment
     if [ -n "$CONDA_PREFIX" ]; then
         # First run the deactivate scripts
-        local _script_dir="${CONDA_PREFIX}/etc/conda/deactivate.d"
+        typeset _script_dir="${CONDA_PREFIX}/etc/conda/deactivate.d"
         if [ -d "$_script_dir" ] && [ -n "$(ls -A "$_script_dir")" ]; then
-            local _path
+            typeset _path
             for _path in "$_script_dir"/*.sh; do
                 . "$_path"
             done
         fi
 
         # Remove env/bin from path
-        local IFS=':'
-        local _target="$CONDA_PREFIX/bin"
-        local _newpath
-        local _path
+        typeset IFS=':'
+        typeset _target="$CONDA_PREFIX/bin"
+        typeset _newpath
+        typeset _path
 
         for _path in $PATH; do
             if [ "$_path" != "$_target" ] ; then

--- a/conda_pack/scripts/posix/parcel
+++ b/conda_pack/scripts/posix/parcel
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-local CDH_PREFIX="${PARCELS_ROOT}/${PARCEL_DIRNAME}"
+typeset CDH_PREFIX="${PARCELS_ROOT}/${PARCEL_DIRNAME}"
 
 if [ -z "${CDH_PYTHON}" ]; then
     export CDH_PYTHON=${CDH_PREFIX}/bin/python
 fi
 
 # Run the activate scripts
-local _script_dir="${CDH_PREFIX}/etc/conda/activate.d"
+typeset _script_dir="${CDH_PREFIX}/etc/conda/activate.d"
 if [ -d "$_script_dir" ] && [ -n "$(ls -A "$_script_dir")" ]; then
-    local _path
+    typeset _path
     for _path in "$_script_dir"/*.sh; do
         . "$_path"
     done


### PR DESCRIPTION
This is to make conda-pack compatible with ksh, where local keyword is not available.

If anyone knows if there is a way to still ensure that the script will work with `sh`, please let me know and I will do the necessary adjustments.