### PR TITLE
Implement tar.xz support

### DIFF
--- a/conda_pack/cli.py
+++ b/conda_pack/cli.py
@@ -70,7 +70,7 @@ def build_parser():
                         "default value is 'el7'. This value cannot have any hyphens.")
     parser.add_argument("--format",
                         choices=['infer', 'zip', 'tar.gz', 'tgz', 'tar.bz2',
-                                 'tbz2', 'tar', 'parcel', 'squashfs'],
+                                 'tbz2', 'tar.xz', 'txz', 'tar', 'parcel', 'squashfs'],
                         default='infer',
                         help=("The archival format to use. By default this is "
                               "inferred by the output file extension."))

--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -237,13 +237,16 @@ class CondaEnv(object):
                 format = 'tar.gz'
             elif output.endswith('.tar.bz2') or output.endswith('.tbz2'):
                 format = 'tar.bz2'
+            elif output.endswith('.tar.xz') or output.endswith('.txz'):
+                format = 'tar.xz'
             elif output.endswith('.tar'):
                 format = 'tar'
             elif output.endswith('.squashfs'):
                 format = 'squashfs'
             else:
                 raise CondaPackException("Unknown file extension %r" % output)
-        elif format not in {'zip', 'tar.gz', 'tgz', 'tar.bz2', 'tbz2', 'tar', 'parcel', 'squashfs'}:
+        elif format not in {'zip', 'tar.gz', 'tgz', 'tar.bz2', 'tbz2',
+                            'tar.xz', 'txz', 'tar', 'parcel', 'squashfs'}:
             raise CondaPackException("Unknown format %r" % format)
         elif output is not None and output.endswith('.parcel'):
             if format not in ('tar.gz', 'tgz'):

--- a/conda_pack/tests/test_core.py
+++ b/conda_pack/tests/test_core.py
@@ -214,7 +214,7 @@ def test_output_and_format(py36_env):
     assert output == 'py36.tar.gz'
     assert format == 'tar.gz'
 
-    for format in ['tar.gz', 'tar.bz2', 'tar', 'zip', 'parcel']:
+    for format in ['tar.gz', 'tar.bz2', 'tar.xz', 'tar', 'zip', 'parcel']:
         output = os.extsep.join([py36_env.name, format])
 
         o, f = py36_env._output_and_format(format=format)

--- a/conda_pack/tests/test_formats.py
+++ b/conda_pack/tests/test_formats.py
@@ -136,7 +136,7 @@ def has_tar_cli():
 
 @pytest.mark.parametrize('format, zip_symlinks', [
     ('zip', True), ('zip', False),
-    ('tar.gz', False), ('tar.bz2', False), ('tar', False),
+    ('tar.gz', False), ('tar.bz2', False), ('tar.xz', False), ('tar', False),
     ('squashfs', False)
 ])
 def test_format(tmpdir, format, zip_symlinks, root_and_paths):
@@ -212,7 +212,7 @@ def test_n_threads():
             _parse_n_threads(n)
 
 
-@pytest.mark.parametrize('format', ['tar.gz', 'tar.bz2'])
+@pytest.mark.parametrize('format', ['tar.gz', 'tar.bz2', 'tar.xz'])
 def test_format_parallel(tmpdir, format, root_and_paths):
     # Python 2's bzip dpesn't support reading multipart files :(
     if format == 'tar.bz2' and PY2:


### PR DESCRIPTION
This enables maximum compression compared to gzip, bzip2 and zstd and is possible with pure Python 3 without any additional dependencies like libarchive-c.