### PR TITLE
Fixes to Windows prefix changes

### DIFF
--- a/conda_pack/prefixes.py
+++ b/conda_pack/prefixes.py
@@ -99,11 +99,12 @@ def text_replace(data, placeholder, new_prefix):
 
 if on_win:
     def binary_replace(data, placeholder, new_prefix):
-        placeholder = placeholder.lower()
         new_prefix = new_prefix.lower()
-        if placeholder not in data:
-            return data
-        return replace_pyzzer_entry_point_shebang(data, placeholder, new_prefix)
+        if placeholder in data:
+            return replace_pyzzer_entry_point_shebang(data, placeholder, new_prefix)
+        elif placeholder.lower() in data:
+            return replace_pyzzer_entry_point_shebang(data, placeholder.lower(), new_prefix)
+        return data
 
 else:
     def binary_replace(data, placeholder, new_prefix):


### PR DESCRIPTION
I have recently started observing that conda-unpack was not properly fixing prefixes of entry points in Windows packages installed with `pip install .`.
This is because conda-pack assumes that the placeholder is in lower-case. But by inspecting the entry point binary I found this not to be the case. This PR solves the issue by trying to fix the entry point using both lower-case and mixed-case forms of the placeholder.

environment:
```
ca-certificates           2021.7.5             haa95532_1
certifi                   2021.5.30        py39haa95532_0
openssl                   1.1.1l               h2bbff1b_0
pip                       21.2.4           py38haa95532_0
python                    3.9.6                h6244533_1
setuptools                52.0.0           py39haa95532_0
snake                     1.0                      pypi_0    pypi  <--- my package installed with `pip install .`, link: https://github.com/guilhermebs/CondaNSIS/tree/main/example/package
sqlite                    3.36.0               h2bbff1b_0
tzdata                    2021a                h5d7bf9c_0
vc                        14.2                 h21ff451_1
vs2015_runtime            14.27.29016          h5e58377_2
wheel                     0.37.0             pyhd3eb1b0_1
wincertstore              0.2              py39h2bbff1b_0
```