### PR TITLE
Support Python 3.10 in `find_site_packages`

### DIFF
--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -570,7 +570,7 @@ def find_site_packages(prefix):
         return 'Lib/site-packages'
 
     python_version = pythons[0]['version']
-    major_minor = python_version[:3]  # e.g. '3.5.1'[:3]
+    major_minor = ".".join(python_version.split(".")[:2])
 
     return 'lib/python%s/site-packages' % major_minor
 


### PR DESCRIPTION
The current implementation of [find_site_packages](https://github.com/conda/conda-pack/blob/ecede405fa4554d3b986256c0456959919039ea0/conda_pack/core.py#L551:575)

extracts the Python version from a string with

https://github.com/conda/conda-pack/blob/ecede405fa4554d3b986256c0456959919039ea0/conda_pack/core.py#L573

This returns `3.1` for Python 3.10, which is not what we want.

This may also address the issue reported in #198.