### PR TITLE
Add fix for core.py missing space

### DIFF
--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -989,7 +989,7 @@ if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(
             prog='conda-unpack',
-            description=('Finish unpacking the environment after unarchiving.'
+            description=('Finish unpacking the environment after unarchiving. '
                          'Cleans up absolute prefixes in any remaining files'))
     parser.add_argument('--version',
                         action='store_true',


### PR DESCRIPTION
A space was missing when running conda-unpack --help between `unarchiving` and `Cleans`
```$ conda unpack --help
usage: conda-unpack [-h] [--version]

Finish unpacking the environment after unarchiving.Cleans up absolute prefixes in any remaining
files

optional arguments:
  -h, --help  show this help message and exit
  --version   Show version then exit```
Now it should be
```
```
$ conda unpack --help
usage: conda-unpack [-h] [--version]

Finish unpacking the environment after unarchiving. Cleans up absolute prefixes in any remaining
files

optional arguments:
  -h, --help  show this help message and exit
  --version   Show version then exit```