### PR TITLE
Rename master to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,12 +2,12 @@ name: Build
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - '*'
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   package:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ See the <a href="https://conda.github.io/conda-pack/">documentation</a>
 for more information.
 
 Conda-pack is offered under a New BSD license; see the
-<a href="https://github.com/conda/conda-pack/blob/master/LICENSE.txt">license file</a>.
+<a href="https://github.com/conda/conda-pack/blob/main/LICENSE.txt">license file</a>.
 
 ## Build status
 
-| [![Build status](https://github.com/conda/conda-pack/workflows/Build%20and%20test%20the%20package/badge.svg)](https://github.com/conda/conda-pack/actions) [![codecov](https://codecov.io/gh/conda/conda-pack/branch/master/graph/badge.svg)](https://codecov.io/gh/conda/conda-pack) | [![Anaconda-Server Badge](https://anaconda.org/ctools/conda-pack/badges/latest_release_date.svg)](https://anaconda.org/ctools/conda-pack) |
+| [![Build status](https://github.com/conda/conda-pack/workflows/Build%20and%20test%20the%20package/badge.svg)](https://github.com/conda/conda-pack/actions) [![codecov](https://codecov.io/gh/conda/conda-pack/branch/main/graph/badge.svg)](https://codecov.io/gh/conda/conda-pack) | [![Anaconda-Server Badge](https://anaconda.org/ctools/conda-pack/badges/latest_release_date.svg)](https://anaconda.org/ctools/conda-pack) |
 | --- | :-: |
 | [`conda install ctools/label/dev::conda-pack`](https://anaconda.org/ctools/conda-pack) | [![Anaconda-Server Badge](https://anaconda.org/ctools/conda-pack/badges/version.svg)](https://anaconda.org/ctools/conda-pack) |
 | [`conda install defaults::conda-pack`](https://anaconda.org/anaconda/conda-pack) | [![Anaconda-Server Badge](https://anaconda.org/anaconda/conda-pack/badges/version.svg)](https://anaconda.org/anaconda/conda-pack) |


### PR DESCRIPTION
The minor modifications needed for renaming the default branch from master to main.

Xref: https://github.com/conda/conda/issues/11517