### PR TITLE
Allow the compression level to be set in zip files

### DIFF
--- a/conda_pack/cli.py
+++ b/conda_pack/cli.py
@@ -75,8 +75,7 @@ def build_parser():
                         default=4,
                         help=("The compression level to use, from 0 to 9. "
                               "Higher numbers decrease output file size at "
-                              "the expense of compression time. Ignored for "
-                              "``format='zip'``. Default is 4."))
+                              "the expense of compression time. Default is 4."))
     parser.add_argument("--n-threads", "-j",
                         metavar="N",
                         type=int,

--- a/conda_pack/formats.py
+++ b/conda_pack/formats.py
@@ -34,8 +34,8 @@ def archive(fileobj, path, arcroot, format, compress_level=4, zip_symlinks=False
     n_threads = _parse_n_threads(n_threads)
 
     if format == 'zip':
-        return ZipArchive(fileobj, arcroot, zip_symlinks=zip_symlinks,
-                          zip_64=zip_64)
+        return ZipArchive(fileobj, arcroot, compresslevel=compress_level,
+                          zip_symlinks=zip_symlinks, zip_64=zip_64)
 
     # Tar archives
     if format in ('tar.gz', 'tgz', 'parcel'):
@@ -294,15 +294,17 @@ tar-based archive format instead."""
 
 
 class ZipArchive(ArchiveBase):
-    def __init__(self, fileobj, arcroot, zip_symlinks=False, zip_64=True):
+    def __init__(self, fileobj, arcroot, compresslevel=4, zip_symlinks=False, zip_64=True):
         self.fileobj = fileobj
         self.arcroot = arcroot
+        self.compresslevel = compresslevel
         self.zip_symlinks = zip_symlinks
         self.zip_64 = zip_64
 
     def __enter__(self):
         self.archive = zipfile.ZipFile(self.fileobj, "w",
                                        allowZip64=self.zip_64,
+                                       compresslevel=self.compresslevel,
                                        compression=zipfile.ZIP_DEFLATED)
         return self
 

--- a/news/252-allow-compression-level-in-zip-files
+++ b/news/252-allow-compression-level-in-zip-files
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Allow the compression level to be set for .zip outputs (#252).
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

Since Python 3.7 the Python zipfile module has allowed setting the
default compression level in zipfiles using the `compresslevel`
argument.

Pass the compression level specified on the command line to the ZipFile class.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?
