### PR TITLE
bugfix: ensure conda-unpack is executable

### DIFF
--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -1111,7 +1111,7 @@ class Packer:
             fil.close()
             st = os.stat(fil.name)
             if executable:
-                os.chmod(fil.name, st.st_mode | 0o111)
+                os.chmod(fil.name, st.st_mode | 0o555)
             self.archive.add(fil.name, fpath)
         finally:
             os.unlink(fil.name)

--- a/conda_pack/tests/test_core.py
+++ b/conda_pack/tests/test_core.py
@@ -47,7 +47,7 @@ def bad_conda_exe(tmpdir_factory, monkeypatch):
     fake_conda = os.path.join(tmpdir, 'conda.bat' if on_win else 'conda')
     with open(fake_conda, 'w') as f:
         f.write('ECHO Failed\r\nEXIT /B 1' if on_win else 'echo "Failed"\nexit 1')
-    os.chmod(fake_conda, os.stat(fake_conda).st_mode | 0o111)
+    os.chmod(fake_conda, os.stat(fake_conda).st_mode | 0o555)
 
     monkeypatch.setenv('PATH', tmpdir, prepend=os.pathsep)
     monkeypatch.delenv('CONDA_EXE', raising=False)


### PR DESCRIPTION
### Description

ensure conda-unpack is executable. 
a file must have both readable and executable flags to be executable.

### Checklist

I didn't find any example to add a news or modify the release notes? If something is needed, can you add or explain me what to add precisely.

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?
