### PR TITLE
Fix path separator on Windows distributions

### DIFF
--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -419,7 +419,11 @@ class File:
         self.target = target
         self.is_conda = is_conda
         self.file_mode = file_mode
-        self.prefix_placeholder = prefix_placeholder
+        self.prefix_placeholder = (
+            prefix_placeholder.replace("\\", "/")
+            if file_mode == "text" and prefix_placeholder is not None
+            else prefix_placeholder
+        )
 
     def __repr__(self):
         return f"File<{self.target!r}, is_conda={self.is_conda!r}>"

--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -1001,11 +1001,11 @@ if __name__ == '__main__':
     else:
         script_dir = os.path.dirname(__file__)
         new_prefix = os.path.abspath(os.path.dirname(script_dir))
-        if on_win:
-            new_prefix = new_prefix.replace('\\\\', '/')
         for path, placeholder, mode in _prefix_records:
-            update_prefix(os.path.join(new_prefix, path), new_prefix,
-                          placeholder, mode=mode)
+            new_path = os.path.join(new_prefix, path)
+            if on_win:
+                new_path = new_path.replace('\\\\', '/')
+            update_prefix(new_path, new_prefix, placeholder, mode=mode)
 """
 
 

--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -419,11 +419,7 @@ class File:
         self.target = target
         self.is_conda = is_conda
         self.file_mode = file_mode
-        self.prefix_placeholder = (
-            prefix_placeholder.replace("\\", "/")
-            if file_mode == "text" and prefix_placeholder is not None
-            else prefix_placeholder
-        )
+        self.prefix_placeholder = prefix_placeholder
 
     def __repr__(self):
         return f"File<{self.target!r}, is_conda={self.is_conda!r}>"
@@ -1005,6 +1001,8 @@ if __name__ == '__main__':
     else:
         script_dir = os.path.dirname(__file__)
         new_prefix = os.path.abspath(os.path.dirname(script_dir))
+        if on_win:
+            new_prefix = new_prefix.replace('\\\\', '/')
         for path, placeholder, mode in _prefix_records:
             update_prefix(os.path.join(new_prefix, path), new_prefix,
                           placeholder, mode=mode)

--- a/conda_pack/prefixes.py
+++ b/conda_pack/prefixes.py
@@ -58,8 +58,9 @@ SHEBANG_REGEX = (
 
 def update_prefix(path, new_prefix, placeholder, mode='text'):
     if on_win and mode == 'text':
-        # force all prefix replacements to forward slashes to simplify need to
+        # force all paths and prefix replacements to forward slashes to simplify need to
         # escape backslashes replace with unix-style path separators
+        path = path.replace('\\', '/')
         new_prefix = new_prefix.replace('\\', '/')
 
     with open(path, 'rb+') as fh:

--- a/conda_pack/prefixes.py
+++ b/conda_pack/prefixes.py
@@ -58,9 +58,8 @@ SHEBANG_REGEX = (
 
 def update_prefix(path, new_prefix, placeholder, mode='text'):
     if on_win and mode == 'text':
-        # force all paths and prefix replacements to forward slashes to simplify need to
+        # force all prefix replacements to forward slashes to simplify need to
         # escape backslashes replace with unix-style path separators
-        path = path.replace('\\', '/')
         new_prefix = new_prefix.replace('\\', '/')
 
     with open(path, 'rb+') as fh:

--- a/news/275-fix-windows-seperator
+++ b/news/275-fix-windows-seperator
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fixed bug in environment path separators preventing unpacking on Windows distributions
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/275-fix-windows-seperator
+++ b/news/275-fix-windows-seperator
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Fixed bug in environment path separators preventing unpacking on Windows distributions
+* Fixed bug in environment path separators preventing unpacking on Windows distributions. (#275)
 
 ### Deprecations
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

I'm experiencing a bug that doesn't allow me to unpack environments on Windows machines, the error presents like so


<img width="765" alt="Screenshot 2023-07-27 at 13 09 01" src="https://github.com/conda/conda-pack/assets/24864257/a666c506-af29-491d-bff0-81e4098ebfbf">


This reproduction is quite minimal, and it seems to affect all packed files with `mode="text"`, so I can only assume it's caused by a mismatching path separator - the prefix is defined [here](https://github.com/conda/conda-pack/blob/031be65749011273c2ffbaf76a47083012f2912d/conda_pack/core.py#L1003C14-L1003C14) using the Windows separator `\`, and the suffix is modified [here](https://github.com/conda/conda-pack/blob/031be65749011273c2ffbaf76a47083012f2912d/conda_pack/prefixes.py#L63) to use the separator `/`, resulting in the mismatch. This PR also modifies the prefix in the same manner, so that the entire path uses the separator `/` in these cases.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205099198501061