### PR TITLE
Use more specific command to list environments

### DIFF
--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -658,7 +658,7 @@ def name_to_prefix(name=None):
     try:
         conda_exe = os.environ.get("CONDA_EXE", "conda")
         info = subprocess.check_output(
-            f"{conda_exe} info --json", shell=True, stderr=subprocess.PIPE
+            f"{conda_exe} env list --json", shell=True, stderr=subprocess.PIPE
         ).decode(default_encoding)
     except subprocess.CalledProcessError as exc:
         kind = ('current environment' if name is None


### PR DESCRIPTION
### Description

This small change uses the more specific `env list` command instead of `info` to retrieve the list of environments. `micromamba` doesn't dump environments in the output of the `info --json` command, so while the change doesn't modify anything when using standard `conda`, it unblocks using `conda-pack` together with `micromamba`.
 
### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?