### PR TITLE
Create the output directory if its missing and `force` is used, otherwise raise 

### DIFF
--- a/conda_pack/cli.py
+++ b/conda_pack/cli.py
@@ -117,7 +117,8 @@ def build_parser():
                         help="Re-add excluded files matching this pattern")
     parser.add_argument("--force", "-f",
                         action="store_true",
-                        help="Overwrite any existing archive at the output path.")
+                        help=("Overwrite any existing archive at the output path, "
+                              "or create the output directory structure if it's missing."))
     parser.add_argument("--quiet", "-q",
                         action="store_true",
                         help="Do not report progress")

--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -285,6 +285,18 @@ class CondaEnv:
         dest_prefix = os.path.join(parcel_root, arcroot)
         return dest_prefix, arcroot, triple
 
+    def _check_output_dir(self, output, force):
+        directory = os.path.dirname(output)
+        if (
+            not directory or  # when passed just a filename, `directory` will be an empty string
+            os.path.exists(directory)
+        ):
+            return
+        if force:
+            os.makedirs(directory)
+            return
+        raise CondaPackException(f"The target output diretory {directory} does not exist")
+
     def pack(
         self,
         output=None,
@@ -385,6 +397,8 @@ class CondaEnv:
             parcel = None
             # Ensure the prefix is a relative path
             arcroot = arcroot.strip(os.path.sep) if arcroot else ""
+
+        self._check_output_dir(output, force)
 
         if os.path.exists(output) and not force:
             raise CondaPackException("File %r already exists" % output)

--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -295,7 +295,7 @@ class CondaEnv:
         if force:
             os.makedirs(directory)
             return
-        raise CondaPackException(f"The target output diretory {directory} does not exist")
+        raise CondaPackException(f"The target output directory {directory} does not exist")
 
     def pack(
         self,

--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -352,8 +352,8 @@ class CondaEnv:
         verbose : bool, optional
             If True, progress is reported to stdout. Default is False.
         force : bool, optional
-            Whether to overwrite any existing archive at the output path.
-            Default is False.
+            Whether to overwrite any existing archive at the output path if present, or
+            create the output directory structure if it's missing. Default is False.
         compress_level : int, optional
             The compression level to use, from 0 to 9. Higher numbers decrease
             output file size at the expense of compression time. Ignored for
@@ -532,8 +532,8 @@ def pack(
     verbose : bool, optional
         If True, progress is reported to stdout. Default is False.
     force : bool, optional
-        Whether to overwrite any existing archive at the output path. Default
-        is False.
+        Whether to overwrite any existing archive at the output path if present, or
+        create the output directory structure if it's missing. Default is False.
     compress_level : int, optional
         The compression level to use, from 0 to 9. Higher numbers decrease
         output file size at the expense of compression time. Ignored for

--- a/conda_pack/tests/test_core.py
+++ b/conda_pack/tests/test_core.py
@@ -102,9 +102,15 @@ def test_ignore_errors_editable_packages():
     CondaEnv.from_prefix(py37_editable_path, ignore_editable_packages=True)
 
 
-def test_errors_when_target_directory_not_exists_and_not_force(py37_env):
+def test_errors_when_target_directory_not_exists_and_not_force(tmpdir, py37_env):
+
+    target_directory = os.path.join(tmpdir, "not_a_real_directory/")
+    assert not os.path.exists(target_directory)
+
+    target_file = os.path.join(target_directory, "env.tar.gz")
+
     with pytest.raises(CondaPackException) as exc:
-        py37_env.pack(output="not_a_real_directory/environment.tar.gz", force=False)
+        py37_env.pack(output=target_file, force=False)
 
     assert "not_a_real_directory" in str(exc.value)
 
@@ -112,7 +118,6 @@ def test_errors_when_target_directory_not_exists_and_not_force(py37_env):
 def test_creates_directories_if_missing_and_force(tmpdir, py37_env):
 
     target_directory = os.path.join(tmpdir, "not_a_real_directory/")
-
     assert not os.path.exists(target_directory)
 
     target_file = os.path.join(target_directory, "env.tar.gz")

--- a/conda_pack/tests/test_core.py
+++ b/conda_pack/tests/test_core.py
@@ -102,6 +102,26 @@ def test_ignore_errors_editable_packages():
     CondaEnv.from_prefix(py37_editable_path, ignore_editable_packages=True)
 
 
+def test_errors_when_target_directory_not_exists_and_not_force(py37_env):
+    with pytest.raises(CondaPackException) as exc:
+        py37_env.pack(output="not_a_real_directory/environment.tar.gz", force=False)
+
+    assert "not_a_real_directory" in str(exc.value)
+
+
+def test_creates_directories_if_missing_and_force(tmpdir, py37_env):
+
+    target_directory = os.path.join(tmpdir, "not_a_real_directory/")
+
+    assert not os.path.exists(target_directory)
+
+    target_file = os.path.join(target_directory, "env.tar.gz")
+
+    py37_env.pack(output=target_file, force=True)
+
+    assert os.path.exists(target_directory)
+
+
 def test_errors_pip_overwrites():
     with pytest.raises(CondaPackException) as exc:
         CondaEnv.from_prefix(py37_broken_path)

--- a/news/295-create-output-dir-if-missing-and-force
+++ b/news/295-create-output-dir-if-missing-and-force
@@ -1,0 +1,21 @@
+### Enhancements
+
+* Creates the output directory if it does not already exist and `force` is used (#295)
+
+* Raise error before packing if the output directory is missing and `force` is not used (#295)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

I've had a couple of occasions where I've used `conda-pack` and asked it to output to a directory that doesn't exist by accident. The packing goes ahead and the operation eventually fails in the `shutil.move()` command right at the end.

I wanted to make it fail early instead or, if `force` was used, to create the directory.

I've gotten it into a 'good enough' working state, and can tidy it up further if you would be open to merging this change.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
