### PR TITLE
Parcel fix

### DIFF
--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -1046,7 +1046,7 @@ _parcel_json_template = """\
 {parcel_packages}
   ],
   "provides": [
-    "spark-plugin"
+    "{parcel_name}"
   ],
   "schema_version": 1,
   "scripts": {{

--- a/news/parcel-provides-enhancement
+++ b/news/parcel-provides-enhancement
@@ -1,4 +1,4 @@
 ### Enhancements
 
-* The provides tag in the parcel.json file was hardcoded to spark-plugin. I have changed this to use the parcel name in case a Cloudera Manager CSD file is being developed to be used in conjunction whtih the generated parcel.
+* The provides tag in the parcel.json file was hardcoded to spark-plugin. This has been changed to use the parcel name in case a Cloudera Manager CSD file is being developed to be used in conjunction whtih the generated parcel.
 

--- a/news/parcel-provides-enhancement
+++ b/news/parcel-provides-enhancement
@@ -1,0 +1,4 @@
+### Enhancements
+
+* The provides field in the parcel.json file was hardcoded to spark-plugin. I have changed this to use the parcel name in case a Cloudera Manager CSD file is being developed to be used in conjunction whtih the generated parcel.
+

--- a/news/parcel-provides-enhancement
+++ b/news/parcel-provides-enhancement
@@ -1,4 +1,4 @@
 ### Enhancements
 
-* The provides field in the parcel.json file was hardcoded to spark-plugin. I have changed this to use the parcel name in case a Cloudera Manager CSD file is being developed to be used in conjunction whtih the generated parcel.
+* The provides tag in the parcel.json file was hardcoded to spark-plugin. I have changed this to use the parcel name in case a Cloudera Manager CSD file is being developed to be used in conjunction whtih the generated parcel.
 


### PR DESCRIPTION
### Description
In the case conda-pack is being used to generate Cloudera parcel files the parcel.json file was generated with static content for the provides tag. The name spark-plugin was set here. The behavior of conda-pack was altered to set the name of the parcel in this tag. In case a CSD is being developed that needs to work together with the generated parcel they can be linked via the provides tag in the parcel : https://github.com/cloudera/cm_ext/wiki/Control-Scripts#interaction-with-parcels