### PR TITLE
Fix crash when using conda-pack on environments created with pixi

### DIFF
--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -890,7 +890,7 @@ def load_environment(prefix, on_missing_cache='warn', ignore_editable_packages=F
             with open(os.path.join(conda_meta, path)) as fil:
                 info = json.load(fil)
 
-            pkg = info['link']['source']
+            pkg = info['link']['source'] if info['link'] else ""
 
             if not os.path.exists(pkg):
                 # Package cache is cleared, set file_mode='unknown' to properly
@@ -930,12 +930,13 @@ def load_environment(prefix, on_missing_cache='warn', ignore_editable_packages=F
                               file_mode=None))
 
     # Add remaining conda metadata files
-    managed.add(os.path.join('conda-meta', 'history'))
-    files.append(File(os.path.join(conda_meta, 'history'),
-                      os.path.join('conda-meta', 'history'),
-                      is_conda=True,
-                      prefix_placeholder=None,
-                      file_mode=None))
+    if os.path.exists(os.path.join(conda_meta, 'history')):
+        managed.add(os.path.join('conda-meta', 'history'))
+        files.append(File(os.path.join(conda_meta, 'history'),
+                        os.path.join('conda-meta', 'history'),
+                        is_conda=True,
+                        prefix_placeholder=None,
+                        file_mode=None))
 
     if missing_files and not ignore_missing_files:
         packages = []
@@ -1019,7 +1020,7 @@ def rewrite_conda_meta(source):
         if field in data:
             data[field] = ""
 
-    if "link" in data and "source" in data["link"]:
+    if "link" in data and data["link"] and "source" in data["link"]:
         data["link"]["source"] = ""
 
     out = json.dumps(data, indent=True, sort_keys=True)

--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -930,13 +930,17 @@ def load_environment(prefix, on_missing_cache='warn', ignore_editable_packages=F
                               file_mode=None))
 
     # Add remaining conda metadata files
-    if os.path.exists(os.path.join(conda_meta, 'history')):
-        managed.add(os.path.join('conda-meta', 'history'))
-        files.append(File(os.path.join(conda_meta, 'history'),
-                        os.path.join('conda-meta', 'history'),
-                        is_conda=True,
-                        prefix_placeholder=None,
-                        file_mode=None))
+    if os.path.exists(os.path.join(conda_meta, "history")):
+        managed.add(os.path.join("conda-meta", "history"))
+        files.append(
+            File(
+                os.path.join(conda_meta, "history"),
+                os.path.join("conda-meta", "history"),
+                is_conda=True,
+                prefix_placeholder=None,
+                file_mode=None,
+            )
+        )
 
     if missing_files and not ignore_missing_files:
         packages = []

--- a/news/support-pixi-environments.md
+++ b/news/support-pixi-environments.md
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix a crash when trying to use conda-pack environments created with [pixi](https://pixi.sh).
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

I tried to use conda-pack with environments created using [pixi](https://pixi.sh). This caused a few issues due to slight variations in the content of the conda-mata files. (E.g. `info['link']` was "null" in my files, and I don't have a `conda-meta/history` file). 

Have added few checks to the code which makes conda-pack work with environments created with pixi. 

I don't know if there is a standard for the conda-meta stuff. If so, the real fix should be in pixi of course. But I hope you will consider my PR anyway.




### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
