### PR TITLE
Fix in SquashFSArchive._add #248

### DIFF
--- a/conda_pack/formats.py
+++ b/conda_pack/formats.py
@@ -439,8 +439,12 @@ class SquashFSArchive(ArchiveBase):
         self._ensure_parent(target_abspath)
 
         # hardlink instead of copy is faster, but it doesn't work across devices
-        same_device = os.lstat(source).st_dev == os.lstat(os.path.dirname(target_abspath)).st_dev
-        if same_device:
+        source_stat = os.lstat(source)
+        target_stat = os.lstat(os.path.dirname(target_abspath))
+        same_device = source_stat.st_dev == target_stat.st_dev
+        same_user = source_stat.st_uid == target_stat.st_uid
+
+        if same_device and same_user:
             copy_func = partial(os.link, follow_symlinks=False)
         else:
             copy_func = partial(shutil.copy2, follow_symlinks=False)

--- a/news/306-fix-hard-link-failure
+++ b/news/306-fix-hard-link-failure
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* In `SquashFSArchive._add` use copy instead of hard-link when source and
+destination do not share file ownership (#248).
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
Can not create hard-link on Linux when source file is owned by root but conda-pack runs as non-root user.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fixing issue #248, when `conda` is installed as `root` and `conda-pack` runs as non-root, hard-linking activate script from conda installation directory to temp folder fails. So we check that source and destination are by the same user and on the same filesystem before deciding to use more efficient link instead of costlier copy.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
