### PR TITLE
Update parcel.rst

### DIFF
--- a/docs/source/parcel.rst
+++ b/docs/source/parcel.rst
@@ -30,7 +30,7 @@ option and four parcel-specific options:
   This is generally expected to follow a standard `semver <https://semver.org/>`_
   format. If not supplied, conda-pack will autogenerate one from today's date in
   ``YYYY.MM.DD`` format.
-- ``--parcel-distribution``: the target distribution for the parcel.
+- ``--parcel-distro``: the target distribution for the parcel.
 
   This is an abbreviation describing the specific operating system on which
   your Cloudera clsuter runs. Its default value is ``el7``, corresponding


### PR DESCRIPTION
The documentation was wrong.  It called the parameter `--parcel-distribution` but it should be `--parcel-distro`.

### Description

See definition in cli.py:
```
    parser.add_argument("--parcel-distro", default=None,
                        help="(Parcels only) The distribution type for the parcel. The "
                        "default value is 'el7'. This value cannot have any hyphens.")
```

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x ] Add / update outdated documentation?
