### PR TITLE
Allow over-writing existing targets

### DIFF
--- a/conda_pack/formats.py
+++ b/conda_pack/formats.py
@@ -506,6 +506,10 @@ class NoArchive(ArchiveBase):
                 self.copy_func = partial(shutil.copy2, follow_symlinks=False)
 
         if os.path.isfile(source) or os.path.islink(source):
+            if os.path.islink(target_abspath) or os.path.isfile(target_abspath):
+                os.remove(target_abspath)
+            elif os.path.isdir(target_abspath):
+                shutil.rmtree(target_abspath)
             self.copy_func(source, target_abspath)
         else:
             os.mkdir(target_abspath)


### PR DESCRIPTION
### Description

Depending on the conda environment, the same file may be written to multiple times (eg. if a specific lib.so file exists, multiple conda packages may have it and at pack time conda-pack will pull from the cache'd original copy of the package and copy it in; when multiple packages have the same lib.so file they'll over-write each other).

shutil.copy2 doesn't handle overwriting existing symlinks cleanly: it overwrites files silently but fails on creating a symlink (probably worth a separate PR to cpython later). Allow for this by explicitly deleting existing targets.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
    - Doesn't seem important enough
- [ ] Add / update necessary tests?
    - **I'll just check what exists and update**
- [x] Add / update outdated documentation?
