### PR TITLE
docs: source file name same as output

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -109,7 +109,7 @@ On the target machine
 
     # Unpack environment into directory `my_env`
     $ mkdir -p my_env
-    $ tar -xzf my_env.tar.gz -C my_env
+    $ tar -xzf out_name.tar.gz -C my_env
 
     # Use python without activating or fixing the prefixes. Most python
     # libraries will work fine, but things that require prefix cleanups


### PR DESCRIPTION
### Description

Tiny PR to change file name in docs.

When following the [command line usage instructions](https://conda.github.io/conda-pack/#commandline-usage) the output file is called `out_name.tar.gz` but in the next step on the source machine it has `my_env.tar.gz`.
This is a problem if someone is following the instructions literally :)