### PR TITLE
Add the deploy step for gh pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,3 +162,24 @@ jobs:
         source $CONDA/bin/activate
         [[ "$GITHUB_REF" =~ ^refs/tags/ ]] || export LABEL="--label dev"
         anaconda --verbose --token $ANACONDA_TOKEN upload --user ctools $LABEL conda-bld/*/*.tar.bz2 --force
+
+  deploy:
+    needs: upload
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4 # or specific "vX.X.X" version tag for this action
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -182,4 +182,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4 # or specific "vX.X.X" version tag for this action
-


### PR DESCRIPTION
### Description

follow up from #376 

you'll need to make some changes on the settings pages

![image](https://github.com/user-attachments/assets/a2c88582-f3ed-4d8c-957e-9ad920392ed6)

then, a multi-step change is needed:
step 1:
![image](https://github.com/user-attachments/assets/2ff2ad8c-cae9-4c4e-9766-442e8fd982ce)
step 2:
![image](https://github.com/user-attachments/assets/1bc34e0d-59b4-488e-804b-986329fa133e)

Once the above things have been set, the docs _should_ push on any tag that gets pushed to this repo.