### PR TITLE
Only deploy docs when release is tagged

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,6 +164,7 @@ jobs:
         anaconda --verbose --token $ANACONDA_TOKEN upload --user ctools $LABEL conda-bld/*/*.tar.bz2 --force
 
   deploy:
+    if: startsWith(github.ref, 'refs/tags/')
     needs: upload
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,9 @@ repos:
     rev: 7.1.1
     hooks:
       - id: flake8
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.29.4
+    hooks:
+      - id: check-dependabot
+      - id: check-github-workflows


### PR DESCRIPTION
We only upload docs when a release is tagged, same constrain has to be applied also to the deploy to avoid artifact not found errors.

This is done under the assumption that it is better to only update the documentation when a release is done. Otherwise we potentially advertise unreleased features in the docs.

While at it also schema checking the changed workflow file.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-pack/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-pack/blob/main/CONTRIBUTING.md -->
