### PR TITLE
Make conda-pack use the new conda plugin mechanism to make it discoverable in mamba

### DIFF
--- a/conda_pack/plugin.py
+++ b/conda_pack/plugin.py
@@ -1,4 +1,5 @@
 import conda.plugins
+
 from conda_pack.cli import main
 
 

--- a/conda_pack/plugin.py
+++ b/conda_pack/plugin.py
@@ -1,5 +1,4 @@
 import conda.plugins
-from conda.base.context import context
 from conda_pack.cli import main
 
 

--- a/conda_pack/plugin.py
+++ b/conda_pack/plugin.py
@@ -1,0 +1,12 @@
+import conda.plugins
+from conda.base.context import context
+from conda_pack.cli import main
+
+
+@conda.plugins.hookimpl
+def conda_subcommands():
+    yield conda.plugins.CondaSubcommand(
+        name="pack",
+        action=main,
+        summary="Package an existing conda environment into an archive file.",
+    )

--- a/setup.py
+++ b/setup.py
@@ -27,11 +27,15 @@ setup(
     long_description_content_type="text/markdown",
     packages=["conda_pack"],
     package_data={"conda_pack": ["scripts/windows/*", "scripts/posix/*"]},
-    entry_points="""
-        [console_scripts]
-        conda-pack=conda_pack.cli:main
-      """,
-    install_requires=["setuptools"],
+    entry_points={
+        'console_scripts': [
+            'conda-pack = conda_pack.cli:main',
+        ],
+        'conda': [
+            'conda-pack = conda_pack.plugin',
+        ],
+    },
+    install_requires=["setuptools", "conda"],
     python_requires=">=3.8",
     zip_safe=False,
 )


### PR DESCRIPTION
### Description

Conda has implemented a new plugin system as introduced here: https://www.anaconda.com/blog/introducing-a-new-plugin-mechanism-for-conda
The old plugin mechanism will be dropped from 26.3 as shown in the message here: https://github.com/conda/conda/blob/89965c01801bd6511c0db5d0944f55108c16f3da/conda/cli/conda_argparse.py#L186

However, mamba doesn't support the old plugin system for quite some time now, and currently `conda-pack` isn't discoverable by `mamba`. With this small change, `conda-pack` will become discoverable by `mamba` and will ensure it's future compatibility with `conda`.

If `conda-pack` doesn't want the dependency on `conda`, it can be easily skipped from `install_requires`, as this entrypoint will only be loaded if `conda` or `mamba` try to discover the plugin and the rest of the code is completely independent from the additions here.