### PR TITLE
Do not overwrite if two packages provide the same file

### DIFF
--- a/conda_pack/formats.py
+++ b/conda_pack/formats.py
@@ -565,7 +565,9 @@ class NoArchive(ArchiveBase):
                 self.copy_func = partial(shutil.copy2, follow_symlinks=False)
 
         if os.path.isfile(source) or os.path.islink(source):
-            self.copy_func(source, target_abspath)
+            # Do not overwrite if the same `target` is added twice.
+            if not os.path.exists(target_abspath):
+                self.copy_func(source, target_abspath)
         else:
             os.mkdir(target_abspath)
 


### PR DESCRIPTION
This should fix issue: #422.

### Description

1. This should fix issue #422 
2. The one drawback is that previous behavior was slightly different where it overwrote the files if the second package provided the same file. Now it skips over them (so it is slightly more efficient).



