### PR TITLE
enh: Use importlib.resources for executable path resolution

### DIFF
--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -11,7 +11,7 @@ import warnings
 from contextlib import contextmanager
 from datetime import datetime
 from fnmatch import fnmatch
-from importlib.resources import files
+from importlib.resources import files as resource_files
 from pathlib import Path
 
 from ._progress import progressbar
@@ -1290,7 +1290,7 @@ class Packer:
 
             if on_win:
                 exe = "cli-32.exe" if is_32bit else "cli-64.exe"
-                cli_exe = str(files("setuptools") / exe)
+                cli_exe = str(resource_files("setuptools") / exe)
                 self.archive.add(cli_exe, os.path.join(BIN_DIR, "conda-unpack.exe"))
 
         # mksquashfs has no (fast) iterative mode, only batch mode

--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -13,7 +13,6 @@ from datetime import datetime
 from fnmatch import fnmatch
 from pathlib import Path
 
-import pkg_resources
 
 from ._progress import progressbar
 from .compat import default_encoding, find_py_source, is_32bit, on_win
@@ -1291,7 +1290,14 @@ class Packer:
 
             if on_win:
                 exe = "cli-32.exe" if is_32bit else "cli-64.exe"
-                cli_exe = pkg_resources.resource_filename("setuptools", exe)
+                try:
+                    # Python 3.9+
+                    from importlib.resources import files
+                    cli_exe = str(files("setuptools") / exe)
+                except ImportError:
+                    # Python < 3.9
+                    import importlib_resources
+                    cli_exe = str(importlib_resources.files("setuptools") / exe)
                 self.archive.add(cli_exe, os.path.join(BIN_DIR, "conda-unpack.exe"))
 
         # mksquashfs has no (fast) iterative mode, only batch mode

--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -11,6 +11,7 @@ import warnings
 from contextlib import contextmanager
 from datetime import datetime
 from fnmatch import fnmatch
+from importlib.resources import files
 from pathlib import Path
 
 from ._progress import progressbar
@@ -1289,14 +1290,7 @@ class Packer:
 
             if on_win:
                 exe = "cli-32.exe" if is_32bit else "cli-64.exe"
-                try:
-                    # Python 3.9+
-                    from importlib.resources import files
-                    cli_exe = str(files("setuptools") / exe)
-                except ImportError:
-                    # Python < 3.9
-                    import importlib_resources
-                    cli_exe = str(importlib_resources.files("setuptools") / exe)
+                cli_exe = str(files("setuptools") / exe)
                 self.archive.add(cli_exe, os.path.join(BIN_DIR, "conda-unpack.exe"))
 
         # mksquashfs has no (fast) iterative mode, only batch mode

--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -13,7 +13,6 @@ from datetime import datetime
 from fnmatch import fnmatch
 from pathlib import Path
 
-
 from ._progress import progressbar
 from .compat import default_encoding, find_py_source, is_32bit, on_win
 from .prefixes import SHEBANG_REGEX, replace_prefix


### PR DESCRIPTION
### Description

This PR addresses the deprecation of `pkg_resources` by migrating to the recommended `importlib.resources` API.

The changes include:
- Adding imports that use `importlib.resources` when available (Python 3.9+)
- Adding a fallback to the `importlib_resources` backport for Python versions < 3.9
- Replacing the use of `pkg_resources.resource_filename()` with the equivalent `importlib.resources.files()` API

This eliminates deprecation warnings when `conda-pack` is imported/used and prepares the codebase for the eventual removal of `pkg_resources`. The backport approach ensures compatibility across Python versions while moving to the modern API.

Fixes #391 
