### PR TITLE
fix: make --format no-archive fail loudly and survive cross-device copies

### DIFF
--- a/conda_pack/formats.py
+++ b/conda_pack/formats.py
@@ -544,7 +544,7 @@ class NoArchive(ArchiveBase):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        return self
+        return False
 
     def _absolute_path(self, path):
         return os.path.normpath(os.path.join(self.output, path))
@@ -565,7 +565,16 @@ class NoArchive(ArchiveBase):
                 self.copy_func = partial(shutil.copy2, follow_symlinks=False)
 
         if os.path.isfile(source) or os.path.islink(source):
-            self.copy_func(source, target_abspath)
+            try:
+                self.copy_func(source, target_abspath)
+            except OSError as exc:
+                if exc.errno != errno.EXDEV:
+                    raise
+                # The device check above only inspects the first file, but a
+                # prefix may span several devices; downgrade to a copy for
+                # this and every following file.
+                self.copy_func = partial(shutil.copy2, follow_symlinks=False)
+                self.copy_func(source, target_abspath)
         else:
             os.mkdir(target_abspath)
 

--- a/conda_pack/tests/test_formats.py
+++ b/conda_pack/tests/test_formats.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import shutil
 import subprocess
@@ -9,12 +10,13 @@ import zipfile
 from multiprocessing import cpu_count
 from os.path import exists, isdir, isfile, islink, join
 from subprocess import STDOUT, check_output
+from unittest import mock
 
 import pytest
 
 from conda_pack.compat import PY2, on_linux, on_mac, on_win
 from conda_pack.core import CondaPackException
-from conda_pack.formats import _parse_n_threads, archive
+from conda_pack.formats import NoArchive, _parse_n_threads, archive
 
 
 @pytest.fixture(scope="module")
@@ -276,3 +278,41 @@ def test_format_parallel(tmpdir, format, root_and_paths):
             out.extractall(out_dir)
 
     check(out_dir, links=(not on_win), root=root)
+
+
+def test_no_archive_does_not_suppress_errors(tmpdir):
+    out_dir = join(str(tmpdir), "test")
+    os.mkdir(out_dir)
+
+    with pytest.raises(ValueError):
+        with NoArchive(out_dir, ""):
+            raise ValueError("should not be swallowed")
+
+
+def test_no_archive_falls_back_to_copy_on_exdev(tmpdir):
+    root = join(str(tmpdir), "src")
+    out_dir = join(str(tmpdir), "test")
+    os.mkdir(root)
+    os.mkdir(out_dir)
+    for name in ["one", "two"]:
+        with open(join(root, name), mode="wb") as fil:
+            fil.write(b"foo bar")
+
+    real_link = os.link
+
+    def link(src, dst, **kwargs):
+        # Emulate a prefix spanning two devices: the first file links fine,
+        # a later one is on another device.
+        if src.endswith("two"):
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+        return real_link(src, dst, **kwargs)
+
+    with mock.patch("os.link", link):
+        with NoArchive(out_dir, "") as arc:
+            for name in ["one", "two"]:
+                arc.add(join(root, name), name)
+
+    for name in ["one", "two"]:
+        assert isfile(join(out_dir, name))
+        with open(join(out_dir, name), mode="rb") as fil:
+            assert fil.read() == b"foo bar"


### PR DESCRIPTION
### Description

Closes #478.

`NoArchive.__exit__` returned `self`, which is always truthy, so per the context manager protocol every exception raised inside the `with` block was suppressed. Combined with `copy_func` being decided from the first file only, a prefix spanning two devices raised `EXDEV` on a later file and `conda pack --format no-archive` exited 0 with a silently incomplete output directory.

`__exit__` now returns `False`, and an `EXDEV` from `os.link` falls back to `shutil.copy2` for that file and the rest of the run.

Two regression tests were added to `conda_pack/tests/test_formats.py`; both fail on `main` (the second with the destination file missing) and pass with the fix.
