### PR TITLE
Add PowerShell activation scripts

### DIFF
--- a/conda_pack/core.py
+++ b/conda_pack/core.py
@@ -37,7 +37,11 @@ if on_win:
     _scripts = [(os.path.join(_current_dir, 'scripts', 'windows', 'activate.bat'),
                  os.path.join(BIN_DIR, 'activate.bat')),
                 (os.path.join(_current_dir, 'scripts', 'windows', 'deactivate.bat'),
-                 os.path.join(BIN_DIR, 'deactivate.bat'))]
+                 os.path.join(BIN_DIR, 'deactivate.bat')),
+                (os.path.join(_current_dir, 'scripts', 'windows', 'activate.ps1'),
+                 os.path.join(BIN_DIR, 'activate.ps1')),
+                (os.path.join(_current_dir, 'scripts', 'windows', 'deactivate.ps1'),
+                 os.path.join(BIN_DIR, 'deactivate.ps1'))]
 else:
     _scripts = [(os.path.join(_current_dir, 'scripts', 'posix', 'activate'),
                  os.path.join(BIN_DIR, 'activate')),
@@ -982,8 +986,9 @@ def load_environment(prefix, on_missing_cache='warn', ignore_editable_packages=F
     # scripts into child environments upon activation. Remove these
     fnames = ('conda', 'activate', 'deactivate')
     if on_win:
-        # Windows includes the POSIX and .bat versions of each
-        fnames = fnames + ('conda.bat', 'activate.bat', 'deactivate.bat')
+        # Windows includes the POSIX, .bat, and PowerShell versions of each
+        fnames = fnames + ('conda.bat', 'activate.bat', 'deactivate.bat',
+                           'activate.ps1', 'deactivate.ps1')
     unmanaged -= {os.path.join(BIN_DIR, f) for f in fnames}
 
     files.extend(File(os.path.join(prefix, p),

--- a/conda_pack/scripts/windows/activate.ps1
+++ b/conda_pack/scripts/windows/activate.ps1
@@ -1,0 +1,39 @@
+# Activate a conda-pack environment in PowerShell.
+
+$newPrefix = Split-Path -Parent $PSScriptRoot
+
+if ($env:CONDA_PREFIX -eq $newPrefix) {
+    return
+}
+
+if ($env:CONDA_PREFIX) {
+    $deactivate = Join-Path $env:CONDA_PREFIX 'Scripts\deactivate.ps1'
+    if (-not (Test-Path -LiteralPath $deactivate)) {
+        $deactivate = Join-Path (Join-Path $env:CONDA_PREFIX '..\..') 'Scripts\deactivate.ps1'
+    }
+    if (Test-Path -LiteralPath $deactivate) {
+        & $deactivate
+    }
+}
+
+$envName = Split-Path -Leaf $newPrefix
+$env:_CONDA_PACK_OLD_PS1 = (Get-Item Function:\prompt -ErrorAction SilentlyContinue).Definition
+$env:_CONDA_PACK_PROMPT_MODIFIER = "($envName) "
+$env:CONDA_PREFIX = $newPrefix
+$env:PATH = "$newPrefix;$newPrefix\Library\mingw-w64\bin;$newPrefix\Library\usr\bin;$newPrefix\Library\bin;$newPrefix\Scripts;$env:PATH"
+
+function global:prompt {
+    $prompt = if ($env:_CONDA_PACK_OLD_PS1) {
+        & ([scriptblock]::Create($env:_CONDA_PACK_OLD_PS1))
+    } else {
+        "PS $($executionContext.SessionState.Path.CurrentLocation)> "
+    }
+    "$env:_CONDA_PACK_PROMPT_MODIFIER$prompt"
+}
+
+$activateScripts = Join-Path $env:CONDA_PREFIX 'etc\conda\activate.d'
+if (Test-Path -LiteralPath $activateScripts) {
+    Get-ChildItem -LiteralPath $activateScripts -Filter '*.ps1' -File |
+        Sort-Object Name |
+        ForEach-Object { . $_.FullName }
+}

--- a/conda_pack/scripts/windows/deactivate.ps1
+++ b/conda_pack/scripts/windows/deactivate.ps1
@@ -1,0 +1,32 @@
+# Deactivate a conda-pack environment in PowerShell.
+
+if (-not $env:CONDA_PREFIX) {
+    return
+}
+
+$activePrefix = $env:CONDA_PREFIX
+$deactivateScripts = Join-Path $activePrefix 'etc\conda\deactivate.d'
+if (Test-Path -LiteralPath $deactivateScripts) {
+    Get-ChildItem -LiteralPath $deactivateScripts -Filter '*.ps1' -File |
+        Sort-Object Name |
+        ForEach-Object { . $_.FullName }
+}
+
+$targets = @(
+    $activePrefix,
+    (Join-Path $activePrefix 'Library\mingw-w64\bin'),
+    (Join-Path $activePrefix 'Library\usr\bin'),
+    (Join-Path $activePrefix 'Library\bin'),
+    (Join-Path $activePrefix 'Scripts')
+)
+$env:PATH = ($env:PATH -split ';' | Where-Object {
+    $entry = $_
+    $entry -and -not ($targets | Where-Object { $_ -ieq $entry })
+}) -join ';'
+$env:CONDA_PREFIX = $null
+
+if ($env:_CONDA_PACK_OLD_PS1) {
+    Set-Item Function:\global:prompt ([scriptblock]::Create($env:_CONDA_PACK_OLD_PS1))
+}
+$env:_CONDA_PACK_OLD_PS1 = $null
+$env:_CONDA_PACK_PROMPT_MODIFIER = $null

--- a/conda_pack/tests/test_core.py
+++ b/conda_pack/tests/test_core.py
@@ -2,6 +2,7 @@ import filecmp
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tarfile
@@ -547,7 +548,8 @@ def test_pack(tmpdir, basic_python_env):
 
     if on_win:
         fnames = ('conda-unpack.exe', 'conda-unpack-script.py',
-                  'conda_unpack_progress.py', 'activate.bat', 'deactivate.bat')
+                  'conda_unpack_progress.py', 'activate.bat', 'deactivate.bat',
+                  'activate.ps1', 'deactivate.ps1')
     else:
         fnames = (
             "conda-unpack",
@@ -697,6 +699,45 @@ def test_activate(tmpdir):
         except (subprocess.CalledProcessError, FileNotFoundError):
             # Skip fish test if fish shell is not available
             pytest.skip("fish shell not available")
+
+
+@pytest.mark.skipif(not on_win, reason="PowerShell is only available on Windows")
+def test_activate_powershell(tmpdir):
+    """The PowerShell scripts activate and deactivate a packed environment."""
+    env_path = tmpdir.mkdir('env')
+    scripts_path = env_path.mkdir('Scripts')
+    source_dir = os.path.join(os.path.dirname(__file__), '..', 'scripts', 'windows')
+    for filename in ('activate.ps1', 'deactivate.ps1'):
+        shutil.copyfile(
+            os.path.join(source_dir, filename),
+            str(scripts_path.join(filename)),
+        )
+
+    command = (
+        "$env:PATH = 'C:\\base'; "
+        ". '{path}\\Scripts\\activate.ps1'; "
+        "Write-Output ('ACTIVE=' + $env:CONDA_PREFIX); "
+        "Write-Output ('PATH=' + $env:PATH); "
+        ". '{path}\\Scripts\\deactivate.ps1'; "
+        "Write-Output ('DEACTIVE=' + $env:CONDA_PREFIX); "
+        "Write-Output ('PATH2=' + $env:PATH)"
+    ).format(path=str(env_path))
+    script = tmpdir.join('powershell_test.ps1')
+    script.write(command)
+
+    try:
+        out = subprocess.check_output(
+            ['powershell.exe', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', str(script)],
+            stderr=subprocess.STDOUT,
+        ).decode()
+    except OSError as exc:
+        if getattr(exc, 'winerror', None) == 6:
+            pytest.skip('The test runner cannot inherit subprocess handles')
+        raise
+
+    assert f'ACTIVE={os.path.normpath(str(env_path))}' in out
+    assert 'DEACTIVE=' in out
+    assert 'PATH2=C:\\base' in out
 
 
 @pytest.mark.skipif(not on_win, reason="Windows-specific test")


### PR DESCRIPTION
Fixes #488.

Add PowerShell activation and deactivation scripts for packed Windows environments, including PATH management, prompt restoration, and activation/deactivation hook execution. The scripts are included in packed Windows environments alongside the existing batch scripts, with a PowerShell regression test.

Tests: `python -m pytest conda_pack/tests/test_prefixes.py conda_pack/tests/test_formats.py -q` (24 passed, 4 skipped); PowerShell behavior was verified directly, while the Python-launched subprocess test is skipped in this sandbox because of `WinError 6`.